### PR TITLE
Replace ordinal based logic to perform enums revert lookup value, by ID based logic

### DIFF
--- a/dualscreen-layout/src/main/java/com/microsoft/device/dualscreen/layout/HingeColor.kt
+++ b/dualscreen-layout/src/main/java/com/microsoft/device/dualscreen/layout/HingeColor.kt
@@ -5,7 +5,16 @@
 
 package com.microsoft.device.dualscreen.layout
 
-internal enum class HingeColor {
-    BLACK,
-    WHITE
+internal enum class HingeColor(val id: Int) {
+    BLACK(0),
+    WHITE(1);
+
+    companion object {
+        fun fromId(id: Int): HingeColor {
+            return values().firstOrNull { it.id == id } ?: throw IllegalArgumentException(
+                "The HingeColor id doesn't exit"
+            )
+        }
+    }
+
 }

--- a/dualscreen-layout/src/main/java/com/microsoft/device/dualscreen/layout/ScreenMode.kt
+++ b/dualscreen-layout/src/main/java/com/microsoft/device/dualscreen/layout/ScreenMode.kt
@@ -5,8 +5,16 @@
 
 package com.microsoft.device.dualscreen.layout
 
-internal enum class ScreenMode {
-    SINGLE_SCREEN,
-    DUAL_SCREEN,
-    NOT_DEFINED
+internal enum class ScreenMode(val id: Int) {
+    SINGLE_SCREEN(0),
+    DUAL_SCREEN(1);
+
+    companion object {
+        fun fromId(id: Int): ScreenMode {
+            return values().firstOrNull { it.id == id } ?: throw IllegalArgumentException(
+                "The ScreenMode id doesn't exit"
+            )
+        }
+    }
+
 }

--- a/dualscreen-layout/src/main/java/com/microsoft/device/dualscreen/layout/SurfaceDuoLayout.kt
+++ b/dualscreen-layout/src/main/java/com/microsoft/device/dualscreen/layout/SurfaceDuoLayout.kt
@@ -43,8 +43,8 @@ open class SurfaceDuoLayout @JvmOverloads constructor(
         val showInDualScreenEnd: Int
         val showInDualScreenStart: Int
         val showInSingleScreen: Int
-        val screenMode: Int
-        val hingeColor: Int
+        val screenMode: ScreenMode
+        val hingeColor: HingeColor
         try {
             singleScreenLayoutId = styledAttributes.getResourceId(
                 R.styleable.SurfaceDuoLayout_single_screen_layout_id,
@@ -70,13 +70,17 @@ open class SurfaceDuoLayout @JvmOverloads constructor(
                 R.styleable.SurfaceDuoLayout_show_in_dual_screen_end,
                 View.NO_ID
             )
-            screenMode = styledAttributes.getResourceId(
-                R.styleable.SurfaceDuoLayout_tools_screen_mode,
-                ScreenMode.SINGLE_SCREEN.ordinal
+            screenMode = ScreenMode.fromId(
+                styledAttributes.getResourceId(
+                    R.styleable.SurfaceDuoLayout_tools_screen_mode,
+                    ScreenMode.SINGLE_SCREEN.id
+                )
             )
-            hingeColor = styledAttributes.getResourceId(
-                R.styleable.SurfaceDuoLayout_tools_hinge_color,
-                HingeColor.BLACK.ordinal
+            hingeColor = HingeColor.fromId(
+                styledAttributes.getResourceId(
+                    R.styleable.SurfaceDuoLayout_tools_hinge_color,
+                    HingeColor.BLACK.id
+                )
             )
         } finally {
             styledAttributes.recycle()
@@ -103,7 +107,6 @@ open class SurfaceDuoLayout @JvmOverloads constructor(
                 } else {
                     dualScreenEndLayoutId
                 }
-
             PreviewRenderer(
                 singleScreenId,
                 dualScreenStartId,
@@ -135,17 +138,17 @@ open class SurfaceDuoLayout @JvmOverloads constructor(
         surfaceDuoLayoutStatusHandler.onConfigurationChanged(this, newConfig)
     }
 
-    inner class PreviewRenderer(
+    private inner class PreviewRenderer(
         singleScreenLayoutId: Int,
         dualScreenStartLayoutId: Int,
         dualScreenEndLayoutId: Int,
-        screenMode: Int,
-        hingeColor: Int
+        screenMode: ScreenMode,
+        hingeColor: HingeColor
     ) {
 
         init {
             when (screenMode) {
-                ScreenMode.SINGLE_SCREEN.ordinal -> {
+                ScreenMode.SINGLE_SCREEN -> {
                     val singleScreenView = LayoutInflater
                         .from(context)
                         .inflate(singleScreenLayoutId, null)
@@ -154,7 +157,7 @@ open class SurfaceDuoLayout @JvmOverloads constructor(
                     this@SurfaceDuoLayout.orientation = VERTICAL
                     this@SurfaceDuoLayout.addView(singleScreenView)
                 }
-                ScreenMode.DUAL_SCREEN.ordinal -> {
+                ScreenMode.DUAL_SCREEN -> {
                     this@SurfaceDuoLayout.weightSum = 2F
                     this@SurfaceDuoLayout.layoutParams = LayoutParams(
                         LayoutParams.MATCH_PARENT,
@@ -163,21 +166,12 @@ open class SurfaceDuoLayout @JvmOverloads constructor(
                     val hinge = FrameLayout(context)
 
                     when (hingeColor) {
-                        HingeColor.BLACK.ordinal -> {
-                            hinge.background = ColorDrawable(
-                                ContextCompat.getColor(context, R.color.black)
-                            )
-                        }
-                        HingeColor.WHITE.ordinal -> {
-                            hinge.background = ColorDrawable(
-                                ContextCompat.getColor(context, R.color.white)
-                            )
-                        }
-                        else -> {
-                            hinge.background = ColorDrawable(
-                                ContextCompat.getColor(context, R.color.black)
-                            )
-                        }
+                        HingeColor.BLACK -> hinge.background = ColorDrawable(
+                            ContextCompat.getColor(context, R.color.black)
+                        )
+                        HingeColor.WHITE -> hinge.background = ColorDrawable(
+                            ContextCompat.getColor(context, R.color.white)
+                        )
                     }
 
                     val dualScreenStartView = LayoutInflater

--- a/dualscreen-layout/src/main/java/com/microsoft/device/dualscreen/layout/SurfaceDuoLayoutStatusHandler.kt
+++ b/dualscreen-layout/src/main/java/com/microsoft/device/dualscreen/layout/SurfaceDuoLayoutStatusHandler.kt
@@ -41,7 +41,7 @@ class SurfaceDuoLayoutStatusHandler internal constructor(
         private const val DEFAULT_RESOURCE_PACKAGE = "android"
     }
 
-    private var screenMode = ScreenMode.NOT_DEFINED
+    private var screenMode = ScreenMode.SINGLE_SCREEN
 
     private var singleScreenView: View? = null
     private var dualScreenStartView: View? = null

--- a/dualscreen-layout/src/test/java/com/microsoft/device/dualscreen/layout/HingeColorTest.kt
+++ b/dualscreen-layout/src/test/java/com/microsoft/device/dualscreen/layout/HingeColorTest.kt
@@ -1,0 +1,20 @@
+package com.microsoft.device.dualscreen.layout
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HingeColorTest {
+
+    @Test
+    fun `test from id`() {
+        assertEquals(HingeColor.fromId(0), HingeColor.BLACK)
+        assertEquals(HingeColor.fromId(1), HingeColor.WHITE)
+        assertEquals(HingeColor.fromId(1), HingeColor.WHITE)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test from illegal id`() {
+        HingeColor.fromId(-1)
+    }
+
+}

--- a/dualscreen-layout/src/test/java/com/microsoft/device/dualscreen/layout/ScreenModeTest.kt
+++ b/dualscreen-layout/src/test/java/com/microsoft/device/dualscreen/layout/ScreenModeTest.kt
@@ -1,0 +1,19 @@
+package com.microsoft.device.dualscreen.layout
+
+import org.junit.Assert
+import org.junit.Test
+
+class ScreenModeTest {
+
+    @Test
+    fun `test from id`() {
+        Assert.assertEquals(ScreenMode.fromId(0), ScreenMode.SINGLE_SCREEN)
+        Assert.assertEquals(ScreenMode.fromId(1), ScreenMode.DUAL_SCREEN)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test from illegal id`() {
+        ScreenMode.fromId(-1)
+    }
+
+}


### PR DESCRIPTION
Please consider this refactor.
Using enum ordinals to perform revert lookup on enums is not considered a good practice, any (un)intentional change on the enum class could provoke a shift in the ordinal that will be unnoticed by the rest of the logic.

This PR adds revert lookup logic based on unique identifiers per enum value; this way, the logic build upon enums will remain valid if the enum class changes.