### PR TITLE
Only layouts that will be shown are inflated

### DIFF
--- a/dualscreen-layout/src/main/java/com/microsoft/device/dualscreen/layout/SurfaceDuoLayoutStatusHandler.kt
+++ b/dualscreen-layout/src/main/java/com/microsoft/device/dualscreen/layout/SurfaceDuoLayoutStatusHandler.kt
@@ -94,17 +94,20 @@ class SurfaceDuoLayoutStatusHandler internal constructor(
      * and add a ScreenModeListener to the SurfaceDuoScreenManager class.
      */
     init {
-        if (singleScreenLayout != -1) {
-            singleScreenView = LayoutInflater.from(activity)
-                .inflate(singleScreenLayout, this.rootView, false)
-        }
-        if (dualScreenLayoutStart != -1) {
-            dualScreenStartView = LayoutInflater.from(activity)
-                .inflate(dualScreenLayoutStart, this.rootView, false)
-        }
-        if (dualScreenLayoutEnd != -1) {
-            dualScreenEndView = LayoutInflater.from(activity)
-                .inflate(dualScreenLayoutEnd, this.rootView, false)
+        if (ScreenHelper.isDualMode(activity)) {
+            if (dualScreenLayoutStart != -1) {
+                dualScreenStartView = LayoutInflater.from(activity)
+                    .inflate(dualScreenLayoutStart, this.rootView, false)
+            }
+            if (dualScreenLayoutEnd != -1) {
+                dualScreenEndView = LayoutInflater.from(activity)
+                    .inflate(dualScreenLayoutEnd, this.rootView, false)
+            }
+        } else {
+            if (singleScreenLayout != -1) {
+                singleScreenView = LayoutInflater.from(activity)
+                    .inflate(singleScreenLayout, this.rootView, false)
+            }
         }
         addViewsDependingOnScreenMode()
     }


### PR DESCRIPTION
SurfaceDuoLayoutStatusHandler will not inflate dualScreenStartView and dualScreenEndView when the application is in single screen mode, and will not inflate singleScreenView when the application is spanned.

I wanted a button in my activity_main_single.xml (single screen layout) and activity_main_second.xml (dual screen end layout) to share the same ID for simplicity in the kotlin code accessing it. I believe this is an OK change since the unused views aren't added into a hierarchy and are inflated again anyway when the activity is recreated via spanning/unspanning. I did not experience issues when using the provided example and my own app in the duo emulator. 