### PR TITLE
Publication trigger improvement

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ name: publish
 # individually in Github Actions view.
 
 on:
-  create:
+  push:
     tags:
       - '*'
   workflow_dispatch:


### PR DESCRIPTION
We wanted that our publication workflow was just triggered **when creating new tags**. 
With the `create` node, the workflow is also triggered when a new branch is created (that means with any new PR) and we don't want that. Here: https://github.community/t/how-to-run-github-actions-workflow-only-for-new-tags/16075/20 is discussed, and using `push` instead of `create` fixes the problem (it's definitely, confusing).

From now on then, the publication workflow will be triggered just **when a new tag is created**.