### PR TITLE
Maven Central feed

### DIFF
--- a/.github/workflows/build_test_check.yml
+++ b/.github/workflows/build_test_check.yml
@@ -46,7 +46,7 @@ jobs:
       - name: unit tests
         run: ./gradlew testDebugUnitTest
       - name: build instrumentation tests
-          run: ./gradlew assembleAndroidTest
+        run: ./gradlew assembleAndroidTest
       - name: lint
         run: ./gradlew lintDebug
       - name: ktlint

--- a/.github/workflows/build_test_check.yml
+++ b/.github/workflows/build_test_check.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: build
+name: build-test-check
 # This workflow builds the different libraries the project has.
 # The workflow is triggered on any PR and when pushing on main branch.
 # It also can run manually if needed.
@@ -11,10 +11,11 @@ on:
   push:
     branches:
       - main
+
   workflow_dispatch:
     inputs:
       name:
-        description: 'manual build trigger'
+        description: 'Manual build-test-check trigger'
       home:
         description: 'location'
         required: false
@@ -40,10 +41,13 @@ jobs:
         run: ./gradlew clean
       - name: assemble debug
         run: ./gradlew assembleDebug
+      - name: assemble release
+        run: ./gradlew assembleRelease
       - name: unit tests
         run: ./gradlew testDebugUnitTest
+      - name: build instrumentation tests
+          run: ./gradlew assembleAndroidTest
       - name: lint
         run: ./gradlew lintDebug
       - name: ktlint
         run: ./gradlew ktlint
-        

--- a/.github/workflows/publish_bintray.yml
+++ b/.github/workflows/publish_bintray.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: publish
+name: publish-bintray
 # This workflow (builds and) publishes the different libraries the project has.
 # Publication gets triggered when a new release-tag is created (we also have manual publishing if needed).
 # Every library publication has its own job, so if one fails the other can run, and we can see them all
@@ -10,11 +10,12 @@ name: publish
 on:
   push:
     tags:
-      - '*'
+      - 'bintray*'
+
   workflow_dispatch:
     inputs:
       name:
-        description: 'manual publish trigger'
+        description: 'Manual publication to bintray/jcenter - dualscreenSDK'
       home:
         description: 'location'
         required: false

--- a/.github/workflows/publish_dualscreenSDK_mavencentral.yml
+++ b/.github/workflows/publish_dualscreenSDK_mavencentral.yml
@@ -25,15 +25,15 @@ jobs:
     strategy:
       matrix:
         projects: [
-          screenmanager:core,
-          screenmanager:dm:library,
-          screenmanager:wm:library,
-          screenmanager:utils,
-          layouts:layouts-library,
-          fragmentshandler:fragmentshandler-library,
-          bottomnavigation:bottomnavigation-library,
-          tabs:tabs-library,
-          recyclerview:recyclerview-library
+          "screenmanager:core",
+          "screenmanager:dm:library",
+          "screenmanager:wm:library",
+          "screenmanager:utils",
+          "layouts:layouts-library",
+          "fragmentshandler:fragmentshandler-library",
+          "bottomnavigation:bottomnavigation-library",
+          "tabs:tabs-library",
+          "recyclerview:recyclerview-library"
         ]
       fail-fast: false
 

--- a/.github/workflows/publish_dualscreenSDK_mavencentral.yml
+++ b/.github/workflows/publish_dualscreenSDK_mavencentral.yml
@@ -2,9 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: publish-dualscreenSDK-mavencentral
-# This workflow builds and publishes the different artifacts the project has..
-# Every library publication has its own job, so if one fails the other can run, and we can see them all
-# individually in Github Actions view.
+# This workflow builds and publishes in Maven Central the DualScreen SDK artifacts (all of them).
+# Although the final publishing step has to be done manually in Sonatype site.
 
 on:
   push:
@@ -75,7 +74,7 @@ jobs:
       - name: Source jar
         run: ./gradlew :${{matrix.projects}}:androidSourcesJar
 
-        # Runs upload, and then closes & releases the repository
+        # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
       - name: Publish to MavenCentral
         run: ./gradlew  :${{matrix.projects}}:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1
         env:

--- a/.github/workflows/publish_dualscreenSDK_mavencentral.yml
+++ b/.github/workflows/publish_dualscreenSDK_mavencentral.yml
@@ -1,0 +1,87 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: publish-dualscreenSDK-mavencentral
+# This workflow builds and publishes the different artifacts the project has..
+# Every library publication has its own job, so if one fails the other can run, and we can see them all
+# individually in Github Actions view.
+
+on:
+  push:
+    tags:
+      - 'dualscreen*'
+
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Manual publication to MavenCentral - dualscreenSDK'
+      home:
+        description: 'location'
+        required: false
+
+jobs:
+  publish-dualscreenSDK:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        projects: [
+          screenmanager:core,
+          screenmanager:dm:library,
+          screenmanager:wm:library,
+          screenmanager:utils,
+          layouts:layouts-library,
+          fragmentshandler:fragmentshandler-library,
+          bottomnavigation:bottomnavigation-library,
+          tabs:tabs-library,
+          recyclerview:recyclerview-library
+        ]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      # Base64 decodes and pipes the GPG key content into the secret file
+      - name: Prepare environment
+        env:
+          SIGNING_SECRET_KEY: ${{ secrets.SIGNING_SECRET_KEY }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}
+        run: |
+          git fetch --unshallow
+          sudo bash -c "echo '$SIGNING_SECRET_KEY' | base64 -d > '$SIGNING_SECRET_FILE'"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: clean
+        run: ./gradlew :${{matrix.projects}}:clean
+
+        # Builds the release artifacts of the library
+      - name: Release build
+        run: ./gradlew :${{matrix.projects}}:assembleRelease
+
+        # Generates other artifacts
+      - name: Source jar
+        run: ./gradlew :${{matrix.projects}}:androidSourcesJar
+
+        # Runs upload, and then closes & releases the repository
+      - name: Publish to MavenCentral
+        run: ./gradlew  :${{matrix.projects}}:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1
+        env:
+          MAVEN_USER: ${{ secrets.MAVEN_USER }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}
+

--- a/.github/workflows/publish_inkSDK_mavencentral.yml
+++ b/.github/workflows/publish_inkSDK_mavencentral.yml
@@ -1,0 +1,69 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: publish-inkSDK-mavencentral
+# This workflow builds and publishes the different artifacts the project has..
+
+on:
+  push:
+    tags:
+      - 'ink*'
+
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Manual publication to MavenCentral - inkSDK'
+      home:
+        description: 'location'
+        required: false
+
+jobs:
+  publish-inkSDK:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      # Base64 decodes and pipes the GPG key content into the secret file
+      - name: Prepare environment
+        env:
+          SIGNING_SECRET_KEY: ${{ secrets.SIGNING_SECRET_KEY }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}
+        run: |
+          git fetch --unshallow
+          sudo bash -c "echo '$SIGNING_SECRET_KEY' | base64 -d > '$SIGNING_SECRET_FILE'"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: clean
+        run: ./gradlew :inksdk:ink:clean
+
+        # Builds the release artifacts of the library
+      - name: Release build
+        run: ./gradlew :inksdk:ink:assembleRelease
+
+        # Generates other artifacts
+      - name: Source jar
+        run: ./gradlew :inksdk:ink:androidSourcesJar
+
+        # Runs upload, and then closes & releases the repository
+      - name: Publish to MavenCentral
+        run: ./gradlew  :inksdk:ink:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1
+        env:
+          MAVEN_USER: ${{ secrets.MAVEN_USER }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}
+

--- a/.github/workflows/publish_inkSDK_mavencentral.yml
+++ b/.github/workflows/publish_inkSDK_mavencentral.yml
@@ -2,7 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: publish-inkSDK-mavencentral
-# This workflow builds and publishes the different artifacts the project has..
+# This workflow builds and publishes in Maven Central the Ink SDK artifact.
+# Although the final publishing step has to be done manually in Sonatype site.
 
 on:
   push:
@@ -57,7 +58,7 @@ jobs:
       - name: Source jar
         run: ./gradlew :inksdk:ink:androidSourcesJar
 
-        # Runs upload, and then closes & releases the repository
+        # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
       - name: Publish to MavenCentral
         run: ./gradlew  :inksdk:ink:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1
         env:

--- a/bottomnavigation/bottomnavigation-library/build.gradle
+++ b/bottomnavigation/bottomnavigation-library/build.gradle
@@ -10,6 +10,13 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
+ext {
+    PUBLISH_GROUP_ID = 'com.microsoft.device.dualscreen'
+    PUBLISH_ARTIFACT_ID = 'bottomnavigation'
+    LIBRARY_DESCRIPTION = 'Library that extends the BottomNavigation component and adapts automatically to the different foldable configurations'
+}
+apply from: "${rootProject.projectDir}/publishing.gradle"
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion

--- a/bottomnavigation/bottomnavigation-library/build.gradle
+++ b/bottomnavigation/bottomnavigation-library/build.gradle
@@ -8,8 +8,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'maven-publish'
-    id 'com.jfrog.bintray'
 }
 
 android {
@@ -38,7 +36,6 @@ android {
     }
 }
 
-
 dependencies {
     api project(':screenmanager:utils')
     compileOnly project(commonDependencies.screenManager)
@@ -54,58 +51,4 @@ dependencies {
     androidTestImplementation commonDependencies.mockitoCore
     androidTestImplementation project(commonDependencies.screenManager)
     androidTestImplementation project(':test-utils')
-}
-
-// ---- Artifact publication -----
-task sourceJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier "sources"
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            MicrosoftSurfaceDuo(MavenPublication) {
-                from components.release
-                groupId 'com.microsoft.device.dualscreen'
-                artifactId 'bottomnavigation'
-                version android.defaultConfig.versionName
-                artifact(sourceJar)
-            }
-        }
-
-        //Private: This is used to upload the artifact to internal repository for testing purposes
-        //You can use it by doing: ./gradlew :module:publishMicrosoftSurfaceDuoPublicationToADORepository
-        //being :module the specific module you want to create the artifact from
-        repositories {
-            maven {
-                name 'ADO'
-                url getPropertyValue("ADO_URL")
-                credentials {
-                    username getPropertyValue("ADO_USER")
-                    password getPropertyValue("ADO_PASSWD")
-                }
-            }
-        }
-    }
-}
-
-//Public: This is used to upload the artifact to Bintray/JCenter
-//You can use it by doing: ./gradlew :module:bintrayUpload
-//being :module the specific module you want to create the artifact from
-bintray {
-    user = getPropertyValue("BINTRAY_USER")
-    key = getPropertyValue("BINTRAY_KEY")
-    publications = ['MicrosoftSurfaceDuo']
-    publish = false
-    pkg {
-        repo = 'components'
-        name = 'bottomnavigation'
-        userOrg = getPropertyValue("BINTRAY_ORG")
-        licenses = ['MIT']
-        version {
-            name = android.defaultConfig.versionName
-            vcsTag = android.defaultConfig.versionName
-        }
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
     ext {
         kotlin_version = rootProject.ext.kotlinVersion
     }
-
     repositories {
         google()
         jcenter()
@@ -19,9 +18,9 @@ buildscript {
     dependencies {
         classpath config.gradlePlugin
         classpath config.kotlinGradlePlugin
-        classpath config.bintrayPlugin
     }
 }
+
 
 allprojects {
     repositories {

--- a/fragmentshandler/fragmentshandler-library/build.gradle
+++ b/fragmentshandler/fragmentshandler-library/build.gradle
@@ -10,6 +10,13 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
+ext {
+    PUBLISH_GROUP_ID = 'com.microsoft.device.dualscreen'
+    PUBLISH_ARTIFACT_ID = 'fragmentshandler'
+    LIBRARY_DESCRIPTION = 'Library that will help you to handle fragments lifecycle when spanning and unspanning an app in a foldable device'
+}
+apply from: "${rootProject.projectDir}/publishing.gradle"
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion

--- a/fragmentshandler/fragmentshandler-library/build.gradle
+++ b/fragmentshandler/fragmentshandler-library/build.gradle
@@ -8,8 +8,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'maven-publish'
-    id 'com.jfrog.bintray'
 }
 
 android {
@@ -60,58 +58,4 @@ dependencies {
     androidTestImplementation project(':layouts:layouts-library')
     androidTestImplementation project(commonDependencies.screenManager)
     androidTestImplementation project(':test-utils')
-}
-
-// ---- Artifact publication -----
-task sourceJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier "sources"
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            MicrosoftSurfaceDuo(MavenPublication) {
-                from components.release
-                groupId 'com.microsoft.device.dualscreen'
-                artifactId 'fragmentshandler'
-                version android.defaultConfig.versionName
-                artifact(sourceJar)
-            }
-        }
-
-        //Private: This is used to upload the artifact to internal repository for testing purposes
-        //You can use it by doing: ./gradlew :module:publishMicrosoftSurfaceDuoPublicationToADORepository
-        //being :module the specific module you want to create the artifact from
-        repositories {
-            maven {
-                name 'ADO'
-                url getPropertyValue("ADO_URL")
-                credentials {
-                    username getPropertyValue("ADO_USER")
-                    password getPropertyValue("ADO_PASSWD")
-                }
-            }
-        }
-    }
-}
-
-//Public: This is used to upload the artifact to Bintray/JCenter
-//You can use it by doing: ./gradlew :module:bintrayUpload
-//being :module the specific module you want to create the artifact from
-bintray {
-    user = getPropertyValue("BINTRAY_USER")
-    key = getPropertyValue("BINTRAY_KEY")
-    publications = ['MicrosoftSurfaceDuo']
-    publish = false
-    pkg {
-        repo = 'components'
-        name = 'fragmentshandler'
-        userOrg = getPropertyValue("BINTRAY_ORG")
-        licenses = ['MIT']
-        version {
-            name = android.defaultConfig.versionName
-            vcsTag = android.defaultConfig.versionName
-        }
-    }
 }

--- a/layouts/layouts-library/build.gradle
+++ b/layouts/layouts-library/build.gradle
@@ -8,8 +8,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'maven-publish'
-    id 'com.jfrog.bintray'
 }
 
 android {
@@ -55,58 +53,4 @@ dependencies {
     androidTestImplementation androidxDependencies.appCompat
     androidTestImplementation project(commonDependencies.screenManager)
     androidTestImplementation project(':test-utils')
-}
-
-// ---- Artifact publication -----
-task sourceJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier "sources"
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            MicrosoftSurfaceDuo(MavenPublication) {
-                from components.release
-                groupId 'com.microsoft.device.dualscreen'
-                artifactId 'layouts'
-                version android.defaultConfig.versionName
-                artifact(sourceJar)
-            }
-        }
-
-        //Private: This is used to upload the artifact to internal repository for testing purposes
-        //You can use it by doing: ./gradlew :module:publishMicrosoftSurfaceDuoPublicationToADORepository
-        //being :module the specific module you want to create the artifact from
-        repositories {
-            maven {
-                name 'ADO'
-                url getPropertyValue("ADO_URL")
-                credentials {
-                    username getPropertyValue("ADO_USER")
-                    password getPropertyValue("ADO_PASSWD")
-                }
-            }
-        }
-    }
-}
-
-//Public: This is used to upload the artifact to Bintray/JCenter
-//You can use it by doing: ./gradlew :module:bintrayUpload
-//being :module the specific module you want to create the artifact from
-bintray {
-    user = getPropertyValue("BINTRAY_USER")
-    key = getPropertyValue("BINTRAY_KEY")
-    publications = ['MicrosoftSurfaceDuo']
-    publish = false
-    pkg {
-        repo = 'components'
-        name = 'layouts'
-        userOrg = getPropertyValue("BINTRAY_ORG")
-        licenses = ['MIT']
-        version {
-            name = android.defaultConfig.versionName
-            vcsTag = android.defaultConfig.versionName
-        }
-    }
 }

--- a/layouts/layouts-library/build.gradle
+++ b/layouts/layouts-library/build.gradle
@@ -10,6 +10,13 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
+ext {
+    PUBLISH_GROUP_ID = 'com.microsoft.device.dualscreen'
+    PUBLISH_ARTIFACT_ID = 'layouts'
+    LIBRARY_DESCRIPTION = 'Different custom layouts that will help you to handle your UI on foldable devices'
+}
+apply from: "${rootProject.projectDir}/publishing.gradle"
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -1,0 +1,110 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+//Every module defines its own values
+group = PUBLISH_GROUP_ID
+version = rootProject.ext.screenManagerWMVersionName
+description = LIBRARY_DESCRIPTION
+
+//Maven central key-value pairs
+ext["signing.keyId"] = getPropertyValue("SIGNING_KEY_ID")
+ext["signing.password"] = getPropertyValue("SIGNING_PASSWORD")
+ext["signing.secretKeyRingFile"] = getPropertyValue("SIGNING_SECRET_FILE")
+ext["mavenUser"] = getPropertyValue("MAVEN_USER")
+ext["mavenPassword"] = getPropertyValue("MAVEN_PASSWORD")
+
+//ADO key-value pairs
+ext["ado_url"] = getPropertyValue("ADO_URL")
+ext["ado_user"] = getPropertyValue("ADO_USER")
+ext["ado_passwd"] = getPropertyValue("ADO_PASSWD")
+
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+    from android.sourceSets.main.kotlin.srcDirs
+}
+
+publishing {
+    publications {
+        SurfaceDuoSDK(MavenPublication) {
+            //Define library main info. Each build.gradle library file define its own data.
+            groupId PUBLISH_GROUP_ID
+            artifactId PUBLISH_ARTIFACT_ID
+            version it.version
+
+            //Set the artifact files
+            artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
+            artifact(androidSourcesJar)
+
+            pom {
+                name = PUBLISH_ARTIFACT_ID
+                description = LIBRARY_DESCRIPTION
+                url = 'https://github.com/microsoft/surface-duo-sdk'
+                licenses {
+                    license {
+                        name = 'MIT'
+                        url = 'https://opensource.org/licenses/MIT'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'MicrosoftSurfaceDuoDevX'
+                        name = 'Microsoft Surface Duo DevX team'
+                        email = 'surfaceduo-devx-libs@microsoft.com'
+                    }
+                }
+                // Version control info
+                scm {
+                    connection = 'scm:git:github.com/microsoft/surface-duo-sdk.git'
+                    developerConnection = 'scm:git:ssh://github.com/microsoft/surface-duo-sdk.git'
+                    url = 'https://github.com/microsoft/surface-duo-sdk/tree/main'
+                }
+                // A slightly hacky fix so that your POM will include any transitive dependencies
+                // that your library builds upon
+                withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+                    project.configurations.implementation.allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+            }
+        }
+    }
+    // Public: This is used to ipload the artifact to the public repository.
+    //You can use it by doing: ./gradlew :module:publishSurfaceDuoSDKToMavenCentralRepository
+    //being :module the specific module you want to create the artifact from
+    repositories {
+        maven {
+            name = "MavenCentral"
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            credentials {
+                username mavenUser
+                password mavenPassword
+            }
+        }
+    }
+
+    //Private: This is used to upload the artifact to internal repository for testing purposes
+    //You can use it by doing: ./gradlew :module:publishSurfaceDuoSDKPublicationToADORepository
+    //being :module the specific module you want to create the artifact from
+    repositories {
+        maven {
+            name 'ADO'
+            url ado_url
+            credentials {
+                username ado_user
+                password ado_passwd
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications
+}

--- a/recyclerview/recyclerview-library/build.gradle
+++ b/recyclerview/recyclerview-library/build.gradle
@@ -10,6 +10,13 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
+ext {
+    PUBLISH_GROUP_ID = 'com.microsoft.device.dualscreen'
+    PUBLISH_ARTIFACT_ID = 'recyclerview'
+    LIBRARY_DESCRIPTION = 'Set of custom components that help you to use a recyclerview on a foldable device handle its different configurations'
+}
+apply from: "${rootProject.projectDir}/publishing.gradle"
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion

--- a/recyclerview/recyclerview-library/build.gradle
+++ b/recyclerview/recyclerview-library/build.gradle
@@ -8,8 +8,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'maven-publish'
-    id 'com.jfrog.bintray'
 }
 
 android {
@@ -54,58 +52,4 @@ dependencies {
     androidTestImplementation instrumentationTestDependencies.testRules
     androidTestImplementation project(commonDependencies.screenManager)
     androidTestImplementation project(':test-utils')
-}
-
-// ---- Artifact publication -----
-task sourceJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier "sources"
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            MicrosoftSurfaceDuo(MavenPublication) {
-                from components.release
-                groupId 'com.microsoft.device.dualscreen'
-                artifactId 'recyclerview'
-                version android.defaultConfig.versionName
-                artifact(sourceJar)
-            }
-        }
-
-        //Private: This is used to upload the artifact to internal repository for testing purposes
-        //You can use it by doing: ./gradlew :module:publishMicrosoftSurfaceDuoPublicationToADORepository
-        //being :module the specific module you want to create the artifact from
-        repositories {
-            maven {
-                name 'ADO'
-                url getPropertyValue("ADO_URL")
-                credentials {
-                    username getPropertyValue("ADO_USER")
-                    password getPropertyValue("ADO_PASSWD")
-                }
-            }
-        }
-    }
-}
-
-//Public: This is used to upload the artifact to Bintray/JCenter
-//You can use it by doing: ./gradlew :module:bintrayUpload
-//being :module the specific module you want to create the artifact from
-bintray {
-    user = getPropertyValue("BINTRAY_USER")
-    key = getPropertyValue("BINTRAY_KEY")
-    publications = ['MicrosoftSurfaceDuo']
-    publish = false
-    pkg {
-        repo = 'components'
-        name = 'recyclerview'
-        userOrg = getPropertyValue("BINTRAY_ORG")
-        licenses = ['MIT']
-        version {
-            name = android.defaultConfig.versionName
-            vcsTag = android.defaultConfig.versionName
-        }
-    }
 }

--- a/screenmanager/core/build.gradle
+++ b/screenmanager/core/build.gradle
@@ -8,8 +8,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'maven-publish'
-    id 'com.jfrog.bintray'
 }
 
 android {
@@ -41,58 +39,4 @@ dependencies {
     testImplementation testDependencies.junit
     androidTestImplementation instrumentationTestDependencies.junit
     androidTestImplementation instrumentationTestDependencies.espressoCore
-}
-
-// ---- Artifact publication -----
-task sourceJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier "sources"
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            MicrosoftSurfaceDuo(MavenPublication) {
-                from components.release
-                groupId 'com.microsoft.device.dualscreen'
-                artifactId 'screenmanager-core'
-                version android.defaultConfig.versionName
-                artifact(sourceJar)
-            }
-        }
-
-        //Private: This is used to upload the artifact to internal repository for testing purposes
-        //You can use it by doing: ./gradlew :module:publishMicrosoftSurfaceDuoPublicationToADORepository
-        //being :module the specific module you want to create the artifact from
-        repositories {
-            maven {
-                name 'ADO'
-                url getPropertyValue("ADO_URL")
-                credentials {
-                    username getPropertyValue("ADO_USER")
-                    password getPropertyValue("ADO_PASSWD")
-                }
-            }
-        }
-    }
-}
-
-//Public: This is used to upload the artifact to Bintray/JCenter
-//You can use it by doing: ./gradlew :module:bintrayUpload
-//being :module the specific module you want to create the artifact from
-bintray {
-    user = getPropertyValue("BINTRAY_USER")
-    key = getPropertyValue("BINTRAY_KEY")
-    publications = ['MicrosoftSurfaceDuo']
-    publish = false
-    pkg {
-        repo = 'screenmanager'
-        name = 'core'
-        userOrg = getPropertyValue("BINTRAY_ORG")
-        licenses = ['MIT']
-        version {
-            name = android.defaultConfig.versionName
-            vcsTag = android.defaultConfig.versionName
-        }
-    }
 }

--- a/screenmanager/core/build.gradle
+++ b/screenmanager/core/build.gradle
@@ -10,6 +10,13 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
+ext {
+    PUBLISH_GROUP_ID = 'com.microsoft.device.dualscreen'
+    PUBLISH_ARTIFACT_ID = 'screenmanager-core'
+    LIBRARY_DESCRIPTION = 'Core library that contains the interfaces and base functionality that the display mask and windowmanager implementations will use.'
+}
+apply from: "${rootProject.projectDir}/publishing.gradle"
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion

--- a/screenmanager/dm/library/build.gradle
+++ b/screenmanager/dm/library/build.gradle
@@ -8,8 +8,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'maven-publish'
-    id 'com.jfrog.bintray'
 }
 
 
@@ -43,58 +41,4 @@ dependencies {
     testImplementation testDependencies.junit
     androidTestImplementation instrumentationTestDependencies.junit
     androidTestImplementation instrumentationTestDependencies.espressoCore
-}
-
-// ---- Artifact publication -----
-task sourceJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier "sources"
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            MicrosoftSurfaceDuo(MavenPublication) {
-                from components.release
-                groupId 'com.microsoft.device.dualscreen'
-                artifactId 'screenmanager-displaymask'
-                version android.defaultConfig.versionName
-                artifact(sourceJar)
-            }
-        }
-
-        //Private: This is used to upload the artifact to internal repository for testing purposes
-        //You can use it by doing: ./gradlew :module:publishMicrosoftSurfaceDuoPublicationToADORepository
-        //being :module the specific module you want to create the artifact from
-        repositories {
-            maven {
-                name 'ADO'
-                url getPropertyValue("ADO_URL")
-                credentials {
-                    username getPropertyValue("ADO_USER")
-                    password getPropertyValue("ADO_PASSWD")
-                }
-            }
-        }
-    }
-}
-
-//Public: This is used to upload the artifact to Bintray/JCenter
-//You can use it by doing: ./gradlew :module:bintrayUpload
-//being :module the specific module you want to create the artifact from
-bintray {
-    user = getPropertyValue("BINTRAY_USER")
-    key = getPropertyValue("BINTRAY_KEY")
-    publications = ['MicrosoftSurfaceDuo']
-    publish = false
-    pkg {
-        repo = 'screenmanager'
-        name = 'displaymask'
-        userOrg = getPropertyValue("BINTRAY_ORG")
-        licenses = ['MIT']
-        version {
-            name = android.defaultConfig.versionName
-            vcsTag = android.defaultConfig.versionName
-        }
-    }
 }

--- a/screenmanager/dm/library/build.gradle
+++ b/screenmanager/dm/library/build.gradle
@@ -10,6 +10,12 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
+ext {
+    PUBLISH_GROUP_ID = 'com.microsoft.device.dualscreen'
+    PUBLISH_ARTIFACT_ID = 'screenmanager-displaymask'
+    LIBRARY_DESCRIPTION = 'Implementation of the screenmanager-core using displaymask'
+}
+apply from: "${rootProject.projectDir}/publishing.gradle"
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/screenmanager/utils/build.gradle
+++ b/screenmanager/utils/build.gradle
@@ -8,8 +8,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'maven-publish'
-    id 'com.jfrog.bintray'
 }
 
 android {
@@ -43,58 +41,4 @@ dependencies {
     testImplementation testDependencies.junit
     androidTestImplementation instrumentationTestDependencies.junit
     androidTestImplementation instrumentationTestDependencies.espressoCore
-}
-
-// ---- Artifact publication -----
-task sourceJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier "sources"
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            MicrosoftSurfaceDuo(MavenPublication) {
-                from components.release
-                groupId 'com.microsoft.device.dualscreen'
-                artifactId 'screenmanager-utils'
-                version android.defaultConfig.versionName
-                artifact(sourceJar)
-            }
-        }
-
-        //Private: This is used to upload the artifact to internal repository for testing purposes
-        //You can use it by doing: ./gradlew :module:publishMicrosoftSurfaceDuoPublicationToADORepository
-        //being :module the specific module you want to create the artifact from
-        repositories {
-            maven {
-                name 'ADO'
-                url getPropertyValue("ADO_URL")
-                credentials {
-                    username getPropertyValue("ADO_USER")
-                    password getPropertyValue("ADO_PASSWD")
-                }
-            }
-        }
-    }
-}
-
-//Public: This is used to upload the artifact to Bintray/JCenter
-//You can use it by doing: ./gradlew :module:bintrayUpload
-//being :module the specific module you want to create the artifact from
-bintray {
-    user = getPropertyValue("BINTRAY_USER")
-    key = getPropertyValue("BINTRAY_KEY")
-    publications = ['MicrosoftSurfaceDuo']
-    publish = false
-    pkg {
-        repo = 'screenmanager'
-        name = 'utils'
-        userOrg = getPropertyValue("BINTRAY_ORG")
-        licenses = ['MIT']
-        version {
-            name = android.defaultConfig.versionName
-            vcsTag = android.defaultConfig.versionName
-        }
-    }
 }

--- a/screenmanager/utils/build.gradle
+++ b/screenmanager/utils/build.gradle
@@ -10,6 +10,13 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
+ext {
+    PUBLISH_GROUP_ID = 'com.microsoft.device.dualscreen'
+    PUBLISH_ARTIFACT_ID = 'screenmanager-utils'
+    LIBRARY_DESCRIPTION = 'Library that contains useful extension functions and code that can be shared between libraries'
+}
+apply from: "${rootProject.projectDir}/publishing.gradle"
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion

--- a/screenmanager/wm/library/build.gradle
+++ b/screenmanager/wm/library/build.gradle
@@ -10,6 +10,13 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
+ext {
+    PUBLISH_GROUP_ID = 'com.microsoft.device.dualscreen'
+    PUBLISH_ARTIFACT_ID = 'screenmanager-windowmanager'
+    LIBRARY_DESCRIPTION = 'Jetpack WindowManager implementation of the screenmanager-core library'
+}
+apply from: "${rootProject.projectDir}/publishing.gradle"
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion

--- a/screenmanager/wm/library/build.gradle
+++ b/screenmanager/wm/library/build.gradle
@@ -8,8 +8,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'maven-publish'
-    id 'com.jfrog.bintray'
 }
 
 android {
@@ -19,7 +17,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-
         versionCode rootProject.ext.screenManagerWMVersionCode
         versionName rootProject.ext.screenManagerWMVersionName
 
@@ -48,58 +45,4 @@ dependencies {
     testImplementation testDependencies.junit
     androidTestImplementation instrumentationTestDependencies.junit
     androidTestImplementation instrumentationTestDependencies.espressoCore
-}
-
-// ---- Artifact publication -----
-task sourceJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier "sources"
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            MicrosoftSurfaceDuo(MavenPublication) {
-                from components.release
-                groupId 'com.microsoft.device.dualscreen'
-                artifactId 'screenmanager-windowmanager'
-                version android.defaultConfig.versionName
-                artifact(sourceJar)
-            }
-        }
-
-        //Private: This is used to upload the artifact to internal repository for testing purposes
-        //You can use it by doing: ./gradlew :module:publishMicrosoftSurfaceDuoPublicationToADORepository
-        //being :module the specific module you want to create the artifact from
-        repositories {
-            maven {
-                name 'ADO'
-                url getPropertyValue("ADO_URL")
-                credentials {
-                    username getPropertyValue("ADO_USER")
-                    password getPropertyValue("ADO_PASSWD")
-                }
-            }
-        }
-    }
-}
-
-//Public: This is used to upload the artifact to Bintray/JCenter
-//You can use it by doing: ./gradlew :module:bintrayUpload
-//being :module the specific module you want to create the artifact from
-bintray {
-    user = getPropertyValue("BINTRAY_USER")
-    key = getPropertyValue("BINTRAY_KEY")
-    publications = ['MicrosoftSurfaceDuo']
-    publish = false
-    pkg {
-        repo = 'screenmanager'
-        name = 'windowmanager'
-        userOrg = getPropertyValue("BINTRAY_ORG")
-        licenses = ['MIT']
-        version {
-            name = android.defaultConfig.versionName
-            vcsTag = android.defaultConfig.versionName
-        }
-    }
 }

--- a/tabs/tabs-library/build.gradle
+++ b/tabs/tabs-library/build.gradle
@@ -10,6 +10,13 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
+ext {
+    PUBLISH_GROUP_ID = 'com.microsoft.device.dualscreen'
+    PUBLISH_ARTIFACT_ID = 'tabs'
+    LIBRARY_DESCRIPTION = 'Extension of the TabsLayout that handles different foldable configurations easily'
+}
+apply from: "${rootProject.projectDir}/publishing.gradle"
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion

--- a/tabs/tabs-library/build.gradle
+++ b/tabs/tabs-library/build.gradle
@@ -8,8 +8,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'maven-publish'
-    id 'com.jfrog.bintray'
 }
 
 android {
@@ -28,13 +26,13 @@ android {
     buildTypes {
         release {
             minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
 }
 
 dependencies {
@@ -52,58 +50,4 @@ dependencies {
     androidTestImplementation commonDependencies.mockitoCore
     androidTestImplementation project(commonDependencies.screenManager)
     androidTestImplementation project(':test-utils')
-}
-
-// ---- Artifact publication -----
-task sourceJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier "sources"
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            MicrosoftSurfaceDuo(MavenPublication) {
-                from components.release
-                groupId 'com.microsoft.device.dualscreen'
-                artifactId 'tabs'
-                version android.defaultConfig.versionName
-                artifact(sourceJar)
-            }
-        }
-
-        //Private: This is used to upload the artifact to internal repository for testing purposes
-        //You can use it by doing: ./gradlew :module:publishMicrosoftSurfaceDuoPublicationToADORepository
-        //being :module the specific module you want to create the artifact from
-        repositories {
-            maven {
-                name 'ADO'
-                url getPropertyValue("ADO_URL")
-                credentials {
-                    username getPropertyValue("ADO_USER")
-                    password getPropertyValue("ADO_PASSWD")
-                }
-            }
-        }
-    }
-}
-
-//Public: This is used to upload the artifact to Bintray/JCenter
-//You can use it by doing: ./gradlew :module:bintrayUpload
-//being :module the specific module you want to create the artifact from
-bintray {
-    user = getPropertyValue("BINTRAY_USER")
-    key = getPropertyValue("BINTRAY_KEY")
-    publications = ['MicrosoftSurfaceDuo']
-    publish = false
-    pkg {
-        repo = 'components'
-        name = 'tabs'
-        userOrg = getPropertyValue("BINTRAY_ORG")
-        licenses = ['MIT']
-        version {
-            name = android.defaultConfig.versionName
-            vcsTag = android.defaultConfig.versionName
-        }
-    }
 }


### PR DESCRIPTION
This branch/PR adds support for publishing (upload) our artifacts to **Maven Central** (Sonatype).
It provides publishing support for both our `dualscreen` libraries and the new (in review) `ink sdk`.

It provides, as well, support for **ADO** publishing (used currently for internal test/usage).

It also refactors the way we use tags to publish in **Bintray/JCenter** (although this will be deleted soon as the service is sunsetting)

