### PR TITLE
ADO artifact feed workflow

### DIFF
--- a/.github/workflows/publish_dualscreenSDK_ado.yml
+++ b/.github/workflows/publish_dualscreenSDK_ado.yml
@@ -2,8 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: publish-dualscreenSDK-ado
-# This workflow builds and publishes in Maven Central the DualScreen SDK artifacts (all of them).
-# Although the final publishing step has to be done manually in Sonatype site.
+# This workflow builds and publishes in ADO the DualScreen SDK artifacts (all of them).
 
 on:
   push:

--- a/.github/workflows/publish_dualscreenSDK_ado.yml
+++ b/.github/workflows/publish_dualscreenSDK_ado.yml
@@ -1,0 +1,74 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: publish-dualscreenSDK-ado
+# This workflow builds and publishes in Maven Central the DualScreen SDK artifacts (all of them).
+# Although the final publishing step has to be done manually in Sonatype site.
+
+on:
+  push:
+    tags:
+      - 'dualscreen*'
+
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Triggers publication to ADO - dualscreenSDK'
+      home:
+        description: 'location'
+        required: false
+
+jobs:
+  publish-dualscreenSDK:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        projects: [
+          "screenmanager:core",
+          "screenmanager:dm:library",
+          "screenmanager:wm:library",
+          "screenmanager:utils",
+          "layouts:layouts-library",
+          "fragmentshandler:fragmentshandler-library",
+          "bottomnavigation:bottomnavigation-library",
+          "tabs:tabs-library",
+          "recyclerview:recyclerview-library"
+        ]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: clean
+        run: ./gradlew :${{matrix.projects}}:clean
+
+        # Builds the release artifacts of the library
+      - name: Release build
+        run: ./gradlew :${{matrix.projects}}:assembleRelease
+
+        # Generates other artifacts
+      - name: Source jar
+        run: ./gradlew :${{matrix.projects}}:androidSourcesJar
+
+        # Runs upload to ADO
+      - name: Publish to ADO
+        run: ./gradlew  :${{matrix.projects}}:publishSurfaceDuoSDKPublicationToADORepository --max-workers 1
+        env:
+          ADO_URL: ${{ secrets.ADO_URL }}
+          ADO_USER: ${{ secrets.ADO_USER }}
+          ADO_PASSWD: ${{ secrets.ADO_PASSWD }}

--- a/.github/workflows/publish_dualscreenSDK_mavencentral.yml
+++ b/.github/workflows/publish_dualscreenSDK_mavencentral.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       name:
-        description: 'Manual publication to MavenCentral - dualscreenSDK'
+        description: 'Triggers publication to MavenCentral - dualscreenSDK'
       home:
         description: 'location'
         required: false

--- a/.github/workflows/publish_inkSDK_ado.yml
+++ b/.github/workflows/publish_inkSDK_ado.yml
@@ -1,0 +1,58 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: publish-inkSDK-ado
+# This workflow builds and publishes in Maven Central the Ink SDK artifact.
+# Although the final publishing step has to be done manually in Sonatype site.
+
+on:
+  push:
+    tags:
+      - 'ink*'
+
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Triggers publication to ADO - inkSDK'
+      home:
+        description: 'location'
+        required: false
+
+jobs:
+  publish-inkSDK:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: clean
+        run: ./gradlew :inksdk:ink:clean
+
+        # Builds the release artifacts of the library
+      - name: Release build
+        run: ./gradlew :inksdk:ink:assembleRelease
+
+        # Generates other artifacts
+      - name: Source jar
+        run: ./gradlew :inksdk:ink:androidSourcesJar
+
+        # Runs upload to ADO
+      - name: Publish to ADO
+        run: ./gradlew  :inksdk:ink:publishSurfaceDuoSDKPublicationToADORepository --max-workers 1
+        env:
+          ADO_URL: ${{ secrets.ADO_URL }}
+          ADO_USER: ${{ secrets.ADO_USER }}
+          ADO_PASSWD: ${{ secrets.ADO_PASSWD }}

--- a/.github/workflows/publish_inkSDK_ado.yml
+++ b/.github/workflows/publish_inkSDK_ado.yml
@@ -2,8 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: publish-inkSDK-ado
-# This workflow builds and publishes in Maven Central the Ink SDK artifact.
-# Although the final publishing step has to be done manually in Sonatype site.
+# This workflow builds and publishes in ADO the Ink SDK artifact.
 
 on:
   push:

--- a/.github/workflows/publish_inkSDK_mavencentral.yml
+++ b/.github/workflows/publish_inkSDK_mavencentral.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       name:
-        description: 'Manual publication to MavenCentral - inkSDK'
+        description: 'Triggers publication to MavenCentral - inkSDK'
       home:
         description: 'location'
         required: false

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -74,7 +74,7 @@ publishing {
             }
         }
     }
-    // Public: This is used to ipload the artifact to the public repository.
+    // Public: This is used to upload the artifact to the public repository.
     //You can use it by doing: ./gradlew :module:publishSurfaceDuoSDKToMavenCentralRepository
     //being :module the specific module you want to create the artifact from
     repositories {
@@ -90,8 +90,9 @@ publishing {
         }
     }
 
-    //Private: This is used to upload the artifact to internal repository for testing purposes
-    //You can use it by doing: ./gradlew :module:publishSurfaceDuoSDKPublicationToADORepository
+    // Public/and for test purposes: This is used to upload the artifact to internal repository
+    // for testing purposes You can use it by doing:
+    // ./gradlew :module:publishSurfaceDuoSDKPublicationToADORepository
     //being :module the specific module you want to create the artifact from
     repositories {
         maven {


### PR DESCRIPTION
This branch/PR handles the artifact publication-workflow into the ADO artifact feed. 
When merged, whenever we release a new dual-screen and/or ink sdks update, the artifacts will be uploaded and published as well in the project's ADO feed.