### PR TITLE
Add field to render with GPU or CPU

### DIFF
--- a/inksdk/ink/src/main/java/com/microsoft/device/ink/InkView.kt
+++ b/inksdk/ink/src/main/java/com/microsoft/device/ink/InkView.kt
@@ -42,6 +42,7 @@ class InkView constructor(
 
     // attributes
     private var enablePressure = false
+    private var renderGPU = true
     private var minStrokeWidth = 1f
     private var maxStrokeWidth = 10f
 
@@ -236,7 +237,7 @@ class InkView constructor(
 
     fun drawHover(cx: Float, cy: Float, radius: Float, pointerType: InputManager.PointerType = InputManager.PointerType.UNKNOWN) {
 
-        val canvas: Canvas = surface?.lockHardwareCanvas() ?: return
+        val canvas: Canvas = if (renderGPU) surface?.lockHardwareCanvas() ?: return else surface?.lockCanvas(null) ?: return
         try {
             // Copy image to the canvas
             canvas.drawBitmap(canvasBitmap, 0f, 0f, overridePaint)
@@ -261,7 +262,7 @@ class InkView constructor(
 
     fun redrawTexture() {
         drawStroke()
-        val canvas: Canvas = surface?.lockHardwareCanvas() ?: return
+        val canvas: Canvas = if (renderGPU) surface?.lockHardwareCanvas() ?: return else surface?.lockCanvas(null) ?: return
         try {
             // Copy image to the canvas
             canvas.drawBitmap(canvasBitmap, 0f, 0f, overridePaint)

--- a/inksdk/ink/src/main/java/com/microsoft/device/ink/InkView.kt
+++ b/inksdk/ink/src/main/java/com/microsoft/device/ink/InkView.kt
@@ -102,6 +102,7 @@ class InkView constructor(
                 color = getColor(R.styleable.InkView_ink_color, color)
                 minStrokeWidth = getFloat(R.styleable.InkView_min_stroke_width, minStrokeWidth)
                 maxStrokeWidth = getFloat(R.styleable.InkView_max_stroke_width, maxStrokeWidth)
+                renderGPU = getBoolean(R.styleable.InkView_render_gpu, renderGPU)
             } finally {
                 recycle()
             }

--- a/inksdk/ink/src/main/res/values/attrs.xml
+++ b/inksdk/ink/src/main/res/values/attrs.xml
@@ -10,6 +10,7 @@
         <attr name="ink_color" format="color" />
         <attr name="min_stroke_width" format="float" />
         <attr name="max_stroke_width" format="float" />
+        <attr name="render_gpu" format="boolean" />
 
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Add "renderGPU" field to choose between `lockHardwareCanvas` (render on GPU) and `lockCanvas` (render on CPU)