### PR TITLE
Fixed BottomNavigation measurement issue on Foldables

### DIFF
--- a/bottomnavigation/bottomnavigation/src/main/java/com/microsoft/device/dualscreen/bottomnavigation/BottomNavigationView.kt
+++ b/bottomnavigation/bottomnavigation/src/main/java/com/microsoft/device/dualscreen/bottomnavigation/BottomNavigationView.kt
@@ -72,7 +72,8 @@ open class BottomNavigationView : BottomNavigationView {
     }
 
     private var job: Job? = null
-    private var singleScreenWidth = -1
+    private var startScreenWidth = -1
+    private var endScreenWidth = -1
     private var totalScreenWidth = -1
     private var hingeWidth = -1
 
@@ -212,10 +213,11 @@ open class BottomNavigationView : BottomNavigationView {
     }
 
     private fun setScreenParameters(foldingFeature: FoldingFeature) {
-        singleScreenWidth = foldingFeature.bounds.left
         totalScreenWidth = context.getWindowRect().right
         foldingFeature.bounds.let {
             hingeWidth = it.right - it.left
+            startScreenWidth = it.left
+            endScreenWidth = totalScreenWidth - it.right
         }
     }
 
@@ -280,15 +282,20 @@ open class BottomNavigationView : BottomNavigationView {
         }
         val startPoint =
             if (firstBtnIndex != 0 || displayPosition == DisplayPosition.END) {
-                singleScreenWidth + hingeWidth
+                windowLayoutInfo.extractFoldingFeatureRect().right
             } else {
                 0
+            }
+        val screenWidth =
+            if (firstBtnIndex != 0 || displayPosition == DisplayPosition.END) {
+                endScreenWidth
+            } else {
+                startScreenWidth
             }
 
         if (defaultChildWidth == -1) {
             defaultChildWidth = getChildAt(0).measuredWidth
         }
-        val screenWidth = singleScreenWidth
 
         val childWidth = if (buttonsCount * defaultChildWidth > screenWidth) {
             screenWidth / buttonsCount
@@ -421,9 +428,10 @@ open class BottomNavigationView : BottomNavigationView {
                 initialBackground
             } else {
                 createHalfTransparentBackground(
+                    initialBackground,
                     displayPosition,
                     windowLayoutInfo.extractFoldingFeatureRect(),
-                    initialBackground
+                    totalScreenWidth
                 )
             }
         }

--- a/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FoldableLayoutSingleScreenTestForSurfaceDuo.kt
+++ b/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FoldableLayoutSingleScreenTestForSurfaceDuo.kt
@@ -27,8 +27,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-private const val ONE_SEC = 1000L
-
 @RunWith(AndroidJUnit4ClassRunner::class)
 class FoldableLayoutSingleScreenTestForSurfaceDuo {
 
@@ -49,7 +47,6 @@ class FoldableLayoutSingleScreenTestForSurfaceDuo {
     @Test
     fun testLayoutSingleScreenLandscape() {
         setOrientationRight()
-        Thread.sleep(ONE_SEC)
 
         onView(withId(R.id.textViewSingle)).check(matches(isDisplayed()))
         onView(withId(R.id.textViewSingle)).check(matches(withText(R.string.single_screen_mode)))
@@ -58,7 +55,6 @@ class FoldableLayoutSingleScreenTestForSurfaceDuo {
     @Test
     fun testLayoutDualScreenLandscape() {
         switchFromSingleToDualScreen()
-        Thread.sleep(ONE_SEC)
 
         onView(withId(R.id.textViewDualStart)).check(matches(isDisplayed()))
         onView(withId(R.id.textViewDualStart)).check(
@@ -80,7 +76,6 @@ class FoldableLayoutSingleScreenTestForSurfaceDuo {
         switchFromSingleToDualScreen()
 
         setOrientationLeft()
-        Thread.sleep(ONE_SEC)
 
         onView(withId(R.id.textViewDualStart)).check(matches(isDisplayed()))
         onView(withId(R.id.textViewDualStart)).check(

--- a/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FoldableLayoutTestOnSecondActivityForSurfaceDuo.kt
+++ b/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FoldableLayoutTestOnSecondActivityForSurfaceDuo.kt
@@ -24,8 +24,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-private const val ONE_SEC = 1000L
-
 @LargeTest
 @RunWith(AndroidJUnit4ClassRunner::class)
 class FoldableLayoutTestOnSecondActivityForSurfaceDuo {
@@ -48,7 +46,6 @@ class FoldableLayoutTestOnSecondActivityForSurfaceDuo {
     @Test
     fun testLayoutSingleScreenLandscape() {
         setOrientationRight()
-        Thread.sleep(ONE_SEC)
 
         onView(withId(R.id.start)).perform(click())
 

--- a/layouts/surfaceduoframelayout-sample/src/main/java/com/microsoft/device/surfaceduo/sample_surfaceduo_viewwrapper/MainActivity.kt
+++ b/layouts/surfaceduoframelayout-sample/src/main/java/com/microsoft/device/surfaceduo/sample_surfaceduo_viewwrapper/MainActivity.kt
@@ -30,6 +30,8 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
         setListeners()
         initWindowLayoutInfo()
     }

--- a/layouts/surfaceduoframelayout-sample/src/main/res/values/dimens.xml
+++ b/layouts/surfaceduoframelayout-sample/src/main/res/values/dimens.xml
@@ -6,6 +6,6 @@
   -->
 
 <resources>
-    <dimen name="position_button_margin">100dp</dimen>
+    <dimen name="position_button_margin">80dp</dimen>
     <dimen name="text_size">32sp</dimen>
 </resources>

--- a/utils/wm-utils/src/main/java/com/microsoft/device/dualscreen/utils/wm/ViewGroupExtensions.kt
+++ b/utils/wm-utils/src/main/java/com/microsoft/device/dualscreen/utils/wm/ViewGroupExtensions.kt
@@ -16,12 +16,13 @@ import androidx.core.content.ContextCompat
  * Used when there are no buttons on one screen.
  */
 fun ViewGroup.createHalfTransparentBackground(
+    initialBackground: Drawable? = null,
     displayPosition: DisplayPosition,
     hinge: Rect?,
-    initialBackground: Drawable? = null
+    totalScreenWidth: Int
 ): Drawable? {
     hinge?.let {
-        val singleScreenWidth = it.left
+
         val hingeWidth = it.right - it.left
 
         val transparentDrawable =
@@ -29,13 +30,13 @@ fun ViewGroup.createHalfTransparentBackground(
         val finalBackground = LayerDrawable(arrayOf(initialBackground, transparentDrawable))
 
         if (displayPosition == DisplayPosition.START) {
-            finalBackground.setLayerInset(0, 0, 0, singleScreenWidth + hingeWidth, 0)
-            finalBackground.setLayerInset(1, singleScreenWidth, 0, 0, 0)
+            finalBackground.setLayerInset(0, 0, 0, totalScreenWidth - it.left, 0)
+            finalBackground.setLayerInset(1, it.left, 0, 0, 0)
         }
 
         if (displayPosition == DisplayPosition.END) {
-            finalBackground.setLayerInset(0, singleScreenWidth + hingeWidth, 0, 0, 0)
-            finalBackground.setLayerInset(1, 0, 0, singleScreenWidth, 0)
+            finalBackground.setLayerInset(0, it.right, 0, 0, 0)
+            finalBackground.setLayerInset(1, 0, 0, totalScreenWidth - it.left, 0)
         }
         return finalBackground
     }


### PR DESCRIPTION
Fixed BottomNavigation measurement issue on Foldables emulators.
The last button in the navigation bar was squashed when the number of the buttons was larger than 4.