### PR TITLE
Specific publication workflow for the TabLayout libary

### DIFF
--- a/.github/workflows/publish_tabs_ado.yml
+++ b/.github/workflows/publish_tabs_ado.yml
@@ -1,0 +1,69 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: publish-tabs-ado
+# This workflow builds and publishes in ADO the TabLayout artifact.
+
+on:
+  push:
+    tags:
+      - 'tabs*'
+
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Triggers publication to ADO - Tabs'
+      home:
+        description: 'location'
+        required: false
+
+jobs:
+  publish-Tabs-ADO:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      # Base64 decodes and pipes the GPG key content into the secret file
+      - name: Prepare environment
+        env:
+          SIGNING_SECRET_KEY: ${{ secrets.SIGNING_SECRET_KEY }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}
+        run: |
+          git fetch --unshallow
+          sudo bash -c "echo '$SIGNING_SECRET_KEY' | base64 -d > '$SIGNING_SECRET_FILE'"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: clean
+        run: ./gradlew :tabs:tabs:clean
+
+        # Builds the release artifacts of the library
+      - name: Release build
+        run: ./gradlew :tabs:tabs:assembleRelease
+
+        # Generates other artifacts
+      - name: Source jar
+        run: ./gradlew :tabs:tabs:androidSourcesJar
+
+        # Runs upload to ADO
+      - name: Publish to ADO
+        run: ./gradlew  :tabs:tabs:publishSurfaceDuoSDKPublicationToADORepository --max-workers 1
+        env:
+          ADO_URL: ${{ secrets.ADO_URL }}
+          ADO_USER: ${{ secrets.ADO_USER }}
+          ADO_PASSWD: ${{ secrets.ADO_PASSWD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}

--- a/.github/workflows/publish_tabs_mavencentral.yml
+++ b/.github/workflows/publish_tabs_mavencentral.yml
@@ -1,0 +1,70 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: publish-tabs-mavencentral
+# This workflow builds and publishes in Maven Central the TabLayout artifact.
+# Although the final publishing step has to be done manually in Sonatype site.
+
+on:
+  push:
+    tags:
+      - 'tabs*'
+
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Triggers publication to MavenCentral - Tabs'
+      home:
+        description: 'location'
+        required: false
+
+jobs:
+  publish-Tabs-MavenCentral:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      # Base64 decodes and pipes the GPG key content into the secret file
+      - name: Prepare environment
+        env:
+          SIGNING_SECRET_KEY: ${{ secrets.SIGNING_SECRET_KEY }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}
+        run: |
+          git fetch --unshallow
+          sudo bash -c "echo '$SIGNING_SECRET_KEY' | base64 -d > '$SIGNING_SECRET_FILE'"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: clean
+        run: ./gradlew :tabs:tabs:clean
+
+        # Builds the release artifacts of the library
+      - name: Release build
+        run: ./gradlew :tabs:tabs:assembleRelease
+
+        # Generates other artifacts
+      - name: Source jar
+        run: ./gradlew :tabs:tabs:androidSourcesJar
+
+        # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
+      - name: Publish to MavenCentral
+        run: ./gradlew  :tabs:tabs:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1
+        env:
+          MAVEN_USER: ${{ secrets.MAVEN_USER }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}
+


### PR DESCRIPTION
This PR adds the workflows needed to publish the TabLayout library to ADO and MavenCentral feeds without the need to build and publish other libs.