### PR TITLE
Added dokka usage to publication workflows

### DIFF
--- a/.github/workflows/publish_bottomnavigation_ado.yml
+++ b/.github/workflows/publish_bottomnavigation_ado.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :bottomnavigation:bottomnavigation:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :bottomnavigation:bottomnavigation:dokkaHtmlJar
+
         # Runs upload to ADO
       - name: Publish to ADO
         run: ./gradlew  :bottomnavigation:bottomnavigation:publishSurfaceDuoSDKPublicationToADORepository --max-workers 1

--- a/.github/workflows/publish_bottomnavigation_mavencentral.yml
+++ b/.github/workflows/publish_bottomnavigation_mavencentral.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :bottomnavigation:bottomnavigation:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :bottomnavigation:bottomnavigation:dokkaHtmlJar
+
         # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
       - name: Publish to MavenCentral
         run: ./gradlew  :bottomnavigation:bottomnavigation:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1

--- a/.github/workflows/publish_dualscreenSDK_ado.yml
+++ b/.github/workflows/publish_dualscreenSDK_ado.yml
@@ -24,16 +24,16 @@ jobs:
     strategy:
       matrix:
         projects: [
-          "screenmanager:screenmanager-core",
-          "screenmanager:dm:screenmanager-displaymask",
-          "screenmanager:wm:screenmanager-windowmanager",
-          "screenmanager:screenmanager-utils",
-          "layouts:layouts",
-          "fragmentshandler:fragmentshandler",
-          "bottomnavigation:bottomnavigation",
-          "tabs:tabs",
-          "recyclerview:recyclerview",
-          "utils:wm-utils"
+            "screenmanager:screenmanager-core",
+            "screenmanager:dm:screenmanager-displaymask",
+            "screenmanager:wm:screenmanager-windowmanager",
+            "screenmanager:screenmanager-utils",
+            "layouts:layouts",
+            "fragmentshandler:fragmentshandler",
+            "bottomnavigation:bottomnavigation",
+            "tabs:tabs",
+            "recyclerview:recyclerview",
+            "utils:wm-utils"
         ]
       fail-fast: false
 
@@ -73,6 +73,10 @@ jobs:
         # Generates other artifacts
       - name: Source jar
         run: ./gradlew :${{matrix.projects}}:androidSourcesJar
+
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :${{matrix.projects}}:dokkaHtmlJar
 
         # Runs upload to ADO
       - name: Publish to ADO

--- a/.github/workflows/publish_dualscreenSDK_ado.yml
+++ b/.github/workflows/publish_dualscreenSDK_ado.yml
@@ -24,16 +24,16 @@ jobs:
     strategy:
       matrix:
         projects: [
-            "screenmanager:screenmanager-core",
-            "screenmanager:dm:screenmanager-displaymask",
-            "screenmanager:wm:screenmanager-windowmanager",
-            "screenmanager:screenmanager-utils",
-            "layouts:layouts",
-            "fragmentshandler:fragmentshandler",
-            "bottomnavigation:bottomnavigation",
-            "tabs:tabs",
-            "recyclerview:recyclerview",
-            "utils:wm-utils"
+          "screenmanager:screenmanager-core",
+          "screenmanager:dm:screenmanager-displaymask",
+          "screenmanager:wm:screenmanager-windowmanager",
+          "screenmanager:screenmanager-utils",
+          "layouts:layouts",
+          "fragmentshandler:fragmentshandler",
+          "bottomnavigation:bottomnavigation",
+          "tabs:tabs",
+          "recyclerview:recyclerview",
+          "utils:wm-utils"
         ]
       fail-fast: false
 

--- a/.github/workflows/publish_dualscreenSDK_mavencentral.yml
+++ b/.github/workflows/publish_dualscreenSDK_mavencentral.yml
@@ -25,16 +25,16 @@ jobs:
     strategy:
       matrix:
         projects: [
-          "screenmanager:screenmanager-core",
-          "screenmanager:dm:screenmanager-displaymask",
-          "screenmanager:wm:screenmanager-windowmanager",
-          "screenmanager:screenmanager-utils",
-          "layouts:layouts",
-          "fragmentshandler:fragmentshandler",
-          "bottomnavigation:bottomnavigation",
-          "tabs:tabs",
-          "recyclerview:recyclerview",
-          "utils:wm-utils"
+            "screenmanager:screenmanager-core",
+            "screenmanager:dm:screenmanager-displaymask",
+            "screenmanager:wm:screenmanager-windowmanager",
+            "screenmanager:screenmanager-utils",
+            "layouts:layouts",
+            "fragmentshandler:fragmentshandler",
+            "bottomnavigation:bottomnavigation",
+            "tabs:tabs",
+            "recyclerview:recyclerview",
+            "utils:wm-utils"
         ]
       fail-fast: false
 
@@ -74,6 +74,10 @@ jobs:
         # Generates other artifacts
       - name: Source jar
         run: ./gradlew :${{matrix.projects}}:androidSourcesJar
+
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :${{matrix.projects}}:dokkaHtmlJar
 
         # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
       - name: Publish to MavenCentral

--- a/.github/workflows/publish_dualscreenSDK_mavencentral.yml
+++ b/.github/workflows/publish_dualscreenSDK_mavencentral.yml
@@ -25,16 +25,16 @@ jobs:
     strategy:
       matrix:
         projects: [
-            "screenmanager:screenmanager-core",
-            "screenmanager:dm:screenmanager-displaymask",
-            "screenmanager:wm:screenmanager-windowmanager",
-            "screenmanager:screenmanager-utils",
-            "layouts:layouts",
-            "fragmentshandler:fragmentshandler",
-            "bottomnavigation:bottomnavigation",
-            "tabs:tabs",
-            "recyclerview:recyclerview",
-            "utils:wm-utils"
+          "screenmanager:screenmanager-core",
+          "screenmanager:dm:screenmanager-displaymask",
+          "screenmanager:wm:screenmanager-windowmanager",
+          "screenmanager:screenmanager-utils",
+          "layouts:layouts",
+          "fragmentshandler:fragmentshandler",
+          "bottomnavigation:bottomnavigation",
+          "tabs:tabs",
+          "recyclerview:recyclerview",
+          "utils:wm-utils"
         ]
       fail-fast: false
 

--- a/.github/workflows/publish_fragmentshandler_ado.yml
+++ b/.github/workflows/publish_fragmentshandler_ado.yml
@@ -1,0 +1,73 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: publish-fragmentshandler-ado
+# This workflow builds and publishes in ADO the FragmentHandler artifact.
+
+on:
+  push:
+    tags:
+      - 'fragmentshandler*'
+
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Triggers publication to ADO - FragmentsHandler'
+      home:
+        description: 'location'
+        required: false
+
+jobs:
+  publish-FragmentsHandler-ADO:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      # Base64 decodes and pipes the GPG key content into the secret file
+      - name: Prepare environment
+        env:
+          SIGNING_SECRET_KEY: ${{ secrets.SIGNING_SECRET_KEY }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}
+        run: |
+          git fetch --unshallow
+          sudo bash -c "echo '$SIGNING_SECRET_KEY' | base64 -d > '$SIGNING_SECRET_FILE'"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: clean
+        run: ./gradlew :fragmentshandler:fragmentshandler:clean
+
+        # Builds the release artifacts of the library
+      - name: Release build
+        run: ./gradlew :fragmentshandler:fragmentshandler:assembleRelease
+
+        # Generates other artifacts
+      - name: Source jar
+        run: ./gradlew :fragmentshandler:fragmentshandler:androidSourcesJar
+
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :fragmentshandler:fragmentshandler:dokkaHtmlJar
+
+        # Runs upload to ADO
+      - name: Publish to ADO
+        run: ./gradlew  :fragmentshandler:fragmentshandler:publishSurfaceDuoSDKPublicationToADORepository --max-workers 1
+        env:
+          ADO_URL: ${{ secrets.ADO_URL }}
+          ADO_USER: ${{ secrets.ADO_USER }}
+          ADO_PASSWD: ${{ secrets.ADO_PASSWD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}

--- a/.github/workflows/publish_fragmentshandler_mavencentral.yml
+++ b/.github/workflows/publish_fragmentshandler_mavencentral.yml
@@ -1,0 +1,74 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: publish-fragmenthandlers-mavencentral
+# This workflow builds and publishes in Maven Central the FragmentsHandler artifact.
+# Although the final publishing step has to be done manually in Sonatype site.
+
+on:
+  push:
+    tags:
+      - 'fragmentshandler*'
+
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Triggers publication to MavenCentral - FragmentsHandler'
+      home:
+        description: 'location'
+        required: false
+
+jobs:
+  publish-FragmentsHandler-MavenCentral:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      # Base64 decodes and pipes the GPG key content into the secret file
+      - name: Prepare environment
+        env:
+          SIGNING_SECRET_KEY: ${{ secrets.SIGNING_SECRET_KEY }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}
+        run: |
+          git fetch --unshallow
+          sudo bash -c "echo '$SIGNING_SECRET_KEY' | base64 -d > '$SIGNING_SECRET_FILE'"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: clean
+        run: ./gradlew :fragmentshandler:fragmentshandler:clean
+
+        # Builds the release artifacts of the library
+      - name: Release build
+        run: ./gradlew :fragmentshandler:fragmentshandler:assembleRelease
+
+        # Generates other artifacts
+      - name: Source jar
+        run: ./gradlew :fragmentshandler:fragmentshandler:androidSourcesJar
+
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :fragmentshandler:fragmentshandler:dokkaHtmlJar
+
+        # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
+      - name: Publish to MavenCentral
+        run: ./gradlew  :fragmentshandler:fragmentshandler:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1
+        env:
+          MAVEN_USER: ${{ secrets.MAVEN_USER }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_SECRET_FILE: ${{ secrets.SIGNING_SECRET_FILE }}
+

--- a/.github/workflows/publish_inkSDK_ado.yml
+++ b/.github/workflows/publish_inkSDK_ado.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :inksdk:ink:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :inksdk:ink:dokkaHtmlJar
+
         # Runs upload to ADO
       - name: Publish to ADO
         run: ./gradlew  :inksdk:ink:publishSurfaceDuoSDKPublicationToADORepository --max-workers 1

--- a/.github/workflows/publish_inkSDK_mavencentral.yml
+++ b/.github/workflows/publish_inkSDK_mavencentral.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :inksdk:ink:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :inksdk:ink:dokkaHtmlJar
+
         # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
       - name: Publish to MavenCentral
         run: ./gradlew  :inksdk:ink:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1

--- a/.github/workflows/publish_layouts_ado.yml
+++ b/.github/workflows/publish_layouts_ado.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :layouts:layouts:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :layouts:layouts:dokkaHtmlJar
+
         # Runs upload to ADO
       - name: Publish to ADO
         run: ./gradlew  :layouts:layouts:publishSurfaceDuoSDKPublicationToADORepository --max-workers 1

--- a/.github/workflows/publish_layouts_mavencentral.yml
+++ b/.github/workflows/publish_layouts_mavencentral.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :layouts:layouts:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :layouts:layouts:dokkaHtmlJar
+
         # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
       - name: Publish to MavenCentral
         run: ./gradlew  :layouts:layouts:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1

--- a/.github/workflows/publish_navigation_component_ado.yml
+++ b/.github/workflows/publish_navigation_component_ado.yml
@@ -71,6 +71,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :${{matrix.projects}}:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :${{matrix.projects}}:dokkaHtmlJar
+
         # Runs upload to ADO
       - name: Publish to ADO
         run: ./gradlew  :${{matrix.projects}}:publishSurfaceDuoSDKPublicationToADORepository --max-workers 1

--- a/.github/workflows/publish_navigation_component_mavencentral.yml
+++ b/.github/workflows/publish_navigation_component_mavencentral.yml
@@ -73,6 +73,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :${{matrix.projects}}:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :${{matrix.projects}}:dokkaHtmlJar
+
         # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
       - name: Publish to MavenCentral
         run: ./gradlew  :${{matrix.projects}}:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1

--- a/.github/workflows/publish_recyclerview_ado.yml
+++ b/.github/workflows/publish_recyclerview_ado.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :recyclerview:recyclerview:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :recyclerview:recyclerview:dokkaHtmlJar
+
         # Runs upload to ADO
       - name: Publish to ADO
         run: ./gradlew  :recyclerview:recyclerview:publishSurfaceDuoSDKPublicationToADORepository --max-workers 1

--- a/.github/workflows/publish_recyclerview_mavencentral.yml
+++ b/.github/workflows/publish_recyclerview_mavencentral.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :recyclerview:recyclerview:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :recyclerview:recyclerview:dokkaHtmlJar
+
         # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
       - name: Publish to MavenCentral
         run: ./gradlew  :recyclerview:recyclerview:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1

--- a/.github/workflows/publish_tabs_ado.yml
+++ b/.github/workflows/publish_tabs_ado.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :tabs:tabs:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :tabs:tabs:dokkaHtmlJar
+
         # Runs upload to ADO
       - name: Publish to ADO
         run: ./gradlew  :tabs:tabs:publishSurfaceDuoSDKPublicationToADORepository --max-workers 1

--- a/.github/workflows/publish_tabs_mavencentral.yml
+++ b/.github/workflows/publish_tabs_mavencentral.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :tabs:tabs:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :tabs:tabs:dokkaHtmlJar
+
         # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
       - name: Publish to MavenCentral
         run: ./gradlew  :tabs:tabs:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1

--- a/.github/workflows/publish_wmutils_ado.yml
+++ b/.github/workflows/publish_wmutils_ado.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :utils:wm-utils:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :utils:wm-utils:dokkaHtmlJar
+
         # Runs upload to ADO
       - name: Publish to ADO
         run: ./gradlew  :utils:wm-utils:publishSurfaceDuoSDKPublicationToADORepository --max-workers 1

--- a/.github/workflows/publish_wmutils_mavencentral.yml
+++ b/.github/workflows/publish_wmutils_mavencentral.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Source jar
         run: ./gradlew :utils:wm-utils:androidSourcesJar
 
+      # Generates docs artifact
+      - name: Docs jar
+        run: ./gradlew :utils:wm-utils:dokkaHtmlJar
+
         # Runs upload to MavenCentral (final release step will be manually done in Sonatype site)
       - name: Publish to MavenCentral
         run: ./gradlew  :utils:wm-utils:publishSurfaceDuoSDKPublicationToMavencentralRepository --max-workers 1

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     apply from: 'dependencies.gradle'
     ext {
         kotlin_version = rootProject.ext.kotlinVersion
+        dokka_version = rootProject.ext.dokkaVersion
     }
     repositories {
         google()
@@ -18,6 +19,7 @@ buildscript {
     dependencies {
         classpath config.gradlePlugin
         classpath config.kotlinGradlePlugin
+        classpath dokkaDependencies.dokkaGradlePlugin
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -47,6 +47,7 @@ ext {
     //Config Android sdk, plugins and libraries version
     gradlePluginVersion = "7.0.2"
     kotlinVersion = "1.5.0"
+    dokkaVersion = "1.6.0"
     compileSdkVersion = 29
     compileSdkVersion2 = 31
     buildToolsVersion = '30.0.3'
@@ -57,11 +58,15 @@ ext {
     config = [
             gradlePlugin             : "com.android.tools.build:gradle:$gradlePluginVersion",
             kotlinGradlePlugin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
-            testInstrumentationRunner: "androidx.test.runner.AndroidJUnitRunner"
+            testInstrumentationRunner: "androidx.test.runner.AndroidJUnitRunner",
     ]
 
     kotlinDependencies = [
-            kotlinStdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+            kotlinStdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion",
+    ]
+
+    dokkaDependencies = [
+            dokkaGradlePlugin: "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
     ]
 
     //AndroidX versions

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -58,11 +58,11 @@ ext {
     config = [
             gradlePlugin             : "com.android.tools.build:gradle:$gradlePluginVersion",
             kotlinGradlePlugin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
-            testInstrumentationRunner: "androidx.test.runner.AndroidJUnitRunner",
+            testInstrumentationRunner: "androidx.test.runner.AndroidJUnitRunner"
     ]
 
     kotlinDependencies = [
-            kotlinStdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion",
+            kotlinStdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     ]
 
     dokkaDependencies = [

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
+apply plugin: 'org.jetbrains.dokka'
 
 //Every module defines its own values
 group = PUBLISH_GROUP_ID
@@ -27,6 +28,19 @@ task androidSourcesJar(type: Jar) {
     from android.sourceSets.main.kotlin.srcDirs
 }
 
+dokkaHtml.configure {
+    dokkaSourceSets {
+        named("main") {
+            noAndroidSdkLink.set(false)
+        }
+    }
+}
+
+task dokkaHtmlJar(type: Jar, dependsOn: dokkaHtml) {
+    archiveClassifier.set('html-doc')
+    from dokkaHtml.outputDirectory
+}
+
 publishing {
     publications {
         SurfaceDuoSDK(MavenPublication) {
@@ -38,6 +52,7 @@ publishing {
             //Set the artifact files
             artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
             artifact(androidSourcesJar)
+            artifact(dokkaHtmlJar)
 
             pom {
                 name = PUBLISH_ARTIFACT_ID


### PR DESCRIPTION
This branch/PR adds the needed bits to setup [dokka](https://github.com/Kotlin/dokka) as the documentation engine for all our libs/workflows.
From now on, all new updates will generate html docs from the source code comments, so we will pack docs, source code and binaries in each artifact.