### PR TITLE
Solved snackbar measurement issue on landscape orientation

### DIFF
--- a/snackbar/sample/build.gradle
+++ b/snackbar/sample/build.gradle
@@ -28,6 +28,7 @@ android {
 
 dependencies {
     implementation project(':snackbar:snackbar')
+    implementation project(':layouts:layouts')
 
     implementation kotlinDependencies.kotlinStdlib
     implementation androidxDependencies.constraintLayout

--- a/snackbar/sample/src/main/res/layout/activity_sample.xml
+++ b/snackbar/sample/src/main/res/layout/activity_sample.xml
@@ -12,6 +12,17 @@
     android:layout_height="match_parent"
     tools:context=".SampleActivity">
 
+    <com.microsoft.device.dualscreen.layouts.FoldableLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:dual_screen_end_layout_id="@layout/dual_screen_end"
+        app:dual_screen_start_layout_id="@layout/dual_screen_start"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:single_screen_layout_id="@layout/single_screen" />
+
     <Button
         android:id="@+id/show_snackbar_to_start"
         android:layout_width="wrap_content"

--- a/snackbar/sample/src/main/res/layout/dual_screen_end.xml
+++ b/snackbar/sample/src/main/res/layout/dual_screen_end.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) Microsoft Corporation. All rights reserved.
+  ~  Licensed under the MIT License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/holo_green_light" />

--- a/snackbar/sample/src/main/res/layout/dual_screen_start.xml
+++ b/snackbar/sample/src/main/res/layout/dual_screen_start.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) Microsoft Corporation. All rights reserved.
+  ~  Licensed under the MIT License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/holo_orange_light" />

--- a/snackbar/sample/src/main/res/layout/single_screen.xml
+++ b/snackbar/sample/src/main/res/layout/single_screen.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) Microsoft Corporation. All rights reserved.
+  ~  Licensed under the MIT License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:background="@android:color/holo_blue_light"
+    android:layout_height="match_parent" />

--- a/snackbar/snackbar/src/main/java/com/microsoft/device/dualscreen/snackbar/ViewExtensions.kt
+++ b/snackbar/snackbar/src/main/java/com/microsoft/device/dualscreen/snackbar/ViewExtensions.kt
@@ -1,0 +1,17 @@
+package com.microsoft.device.dualscreen.snackbar
+
+import android.view.View
+
+data class Point(val x: Int, val y: Int)
+
+/**
+ * <p>Computes the coordinates of this view on the screen.
+ *
+ * @return a [Point] object that holds the coordinates
+ */
+val View.locationOnScreen: Point
+    get() {
+        val location = IntArray(2)
+        getLocationOnScreen(location)
+        return Point(location[0], location[1])
+    }


### PR DESCRIPTION
<!---
Instructions: Please, fill the following sections with the information that is suggested in the comments. You can leave the comments or delete them, it won't be shown in the PR.
-->

## 📃 Description
SnackbarContainer does not have the correct margin when it is in landscape orientation

## 🤔 Motivation and Context
The SnackbarContainer does not add a margin between the Snackbar and the navigation bar.
Also, I added some colors for the single/start/end display area in order to be easy to detect the display area on other foldable devices.

## 🧪 How Has This Been Tested?
Manually, with SurfaceDuo emulator, SurfaceDuo1&2 and other foldable devices/emulators

## ⚒️ Does the PR contain new tests or refactored old ones?
No

## 📷 Screenshots (if appropriate)
![Screenshot_1650539005](https://user-images.githubusercontent.com/72752597/164444973-1c70bbf7-2306-4ec6-916d-3a2b3382e1ba.png)
![Screenshot_1650539013](https://user-images.githubusercontent.com/72752597/164445019-81f41add-4e50-4662-a49a-04fff687708e.png)
![Screenshot_1650539017](https://user-images.githubusercontent.com/72752597/164445034-a3f4dcdc-a82c-43c7-a9e8-f5f8a8a538cf.png)


## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement to a current functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue. Please add issue link here too).

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] This PR contains new tests that cover the new code.
- [ ] This PR refactor previous tests to cover the new code.
- [ ] This PR is part of a set of PRs that build a bigger feature. If so, please, add here links to previously merged or open PRs.

<!--
Credits:
- [Cortinico](https://github.com/cortinico/kotlin-android-template/tree/main/.github)
- [Fluent UI team](https://github.com/microsoft/fluentui-android/tree/master/.github)

for their fantastic templates that have helped us as inspiration.
-->