### PR TITLE
Annotations for Foldable devices AndroidTests

### DIFF
--- a/bottomnavigation/bottomnavigation/build.gradle
+++ b/bottomnavigation/bottomnavigation/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     androidTestImplementation project(':utils:test-utils')
     androidTestImplementation commonDependencies.mockitoDexMaker
     androidTestImplementation commonDependencies.mockitoCore
-    androidTestImplementation instrumentationTestDependencies.junit
+    androidTestImplementation instrumentationTestDependencies.junitKtx
     androidTestImplementation instrumentationTestDependencies.testRules
     androidTestImplementation instrumentationTestDependencies.espressoCore
     androidTestImplementation instrumentationTestDependencies.uiAutomator

--- a/bottomnavigation/bottomnavigation/src/androidTest/java/com/microsoft/device/dualscreen/bottomnavigation/SurfaceDuoBottomNavigationTest.kt
+++ b/bottomnavigation/bottomnavigation/src/androidTest/java/com/microsoft/device/dualscreen/bottomnavigation/SurfaceDuoBottomNavigationTest.kt
@@ -9,10 +9,9 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.filters.MediumTest
-import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiDevice
 import com.microsoft.device.dualscreen.bottomnavigation.test.R
 import com.microsoft.device.dualscreen.bottomnavigation.utils.SimpleBottomNavigationActivity
@@ -22,21 +21,30 @@ import com.microsoft.device.dualscreen.bottomnavigation.utils.changeDisplayPosit
 import com.microsoft.device.dualscreen.bottomnavigation.utils.checkChildCount
 import com.microsoft.device.dualscreen.bottomnavigation.utils.disableAnimation
 import com.microsoft.device.dualscreen.bottomnavigation.utils.hasHalfTransparentBackground
+import com.microsoft.device.dualscreen.testing.DeviceModel
+import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
+import com.microsoft.device.dualscreen.testing.filters.TargetDevice
+import com.microsoft.device.dualscreen.testing.rules.DualScreenTestRule
+import com.microsoft.device.dualscreen.testing.rules.foldableTestRule
+import com.microsoft.device.dualscreen.testing.runner.FoldableJUnit4ClassRunner
 import com.microsoft.device.dualscreen.testing.spanFromStart
 import com.microsoft.device.dualscreen.utils.wm.DisplayPosition
 import org.hamcrest.Matchers
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 
 @MediumTest
-@RunWith(AndroidJUnit4ClassRunner::class)
+@RunWith(FoldableJUnit4ClassRunner::class)
 class SurfaceDuoBottomNavigationTest {
+    private val activityScenarioRule = activityScenarioRule<SimpleBottomNavigationActivity>()
+    private val dualScreenTestRule = DualScreenTestRule()
+    private val uiDevice: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
     @get:Rule
-    val activityTestRule = ActivityTestRule(SimpleBottomNavigationActivity::class.java)
-    private val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    val testRule: TestRule = foldableTestRule(activityScenarioRule, dualScreenTestRule)
 
     @Before
     fun before() {
@@ -44,64 +52,66 @@ class SurfaceDuoBottomNavigationTest {
     }
 
     @Test
+    @DualScreenTest
     fun testDisplayPositionFromLayout() {
-        uiDevice.spanFromStart()
         onView(withId(R.id.nav_view)).check(matches(areTabsOnScreen(DisplayPosition.DUAL)))
     }
 
     @Test
+    @DualScreenTest
     fun testDisplayPositionStart() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(DisplayPosition.START)
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testDisplayPositionEnd() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(DisplayPosition.END)
     }
 
     @Test
+    @DualScreenTest
     fun testDisplayPositionDual() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(DisplayPosition.DUAL)
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testButtonSplit0_5() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(0, 5, DisplayPosition.END)
     }
 
     @Test
+    @DualScreenTest
     fun testButtonSplit1_4() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(1, 4, DisplayPosition.DUAL)
     }
 
     @Test
+    @DualScreenTest
     fun testButtonSplit2_3() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(2, 3, DisplayPosition.DUAL)
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testButtonSplit5_0() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(0, 5, DisplayPosition.END)
     }
 
     @Test
+    @DualScreenTest
     fun testButtonSplit_invalid() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(5, 0, DisplayPosition.START)
         arrangeButtonsAndCheckPosition(5, 5, DisplayPosition.START)
     }
 
     @Test
+    @DualScreenTest
     fun testSwipeLeft() {
-        uiDevice.spanFromStart()
-
         onView(withId(R.id.nav_view)).perform(changeButtonArrangement(2, 3))
 
         onView(withId(R.id.nav_view)).perform(ViewActions.swipeLeft())
@@ -109,9 +119,9 @@ class SurfaceDuoBottomNavigationTest {
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testSwipeRight() {
-        uiDevice.spanFromStart()
-
         onView(withId(R.id.nav_view)).perform(changeButtonArrangement(2, 3))
 
         onView(withId(R.id.nav_view)).perform(ViewActions.swipeRight())
@@ -119,9 +129,9 @@ class SurfaceDuoBottomNavigationTest {
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testMultipleSwipes() {
-        uiDevice.spanFromStart()
-
         onView(withId(R.id.nav_view)).perform(changeButtonArrangement(2, 3))
 
         onView(withId(R.id.nav_view)).perform(ViewActions.swipeLeft())
@@ -141,9 +151,9 @@ class SurfaceDuoBottomNavigationTest {
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testTransparentBackground() {
-        uiDevice.spanFromStart()
-
         onView(withId(R.id.nav_view)).check(matches(areTabsOnScreen(DisplayPosition.DUAL)))
         onView(withId(R.id.nav_view)).check(matches(Matchers.not(hasHalfTransparentBackground())))
 

--- a/bottomnavigation/bottomnavigation/src/androidTest/java/com/microsoft/device/dualscreen/bottomnavigation/SurfaceDuoBottomNavigationTest.kt
+++ b/bottomnavigation/bottomnavigation/src/androidTest/java/com/microsoft/device/dualscreen/bottomnavigation/SurfaceDuoBottomNavigationTest.kt
@@ -21,9 +21,7 @@ import com.microsoft.device.dualscreen.bottomnavigation.utils.changeDisplayPosit
 import com.microsoft.device.dualscreen.bottomnavigation.utils.checkChildCount
 import com.microsoft.device.dualscreen.bottomnavigation.utils.disableAnimation
 import com.microsoft.device.dualscreen.bottomnavigation.utils.hasHalfTransparentBackground
-import com.microsoft.device.dualscreen.testing.DeviceModel
 import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
-import com.microsoft.device.dualscreen.testing.filters.TargetDevice
 import com.microsoft.device.dualscreen.testing.rules.DualScreenTestRule
 import com.microsoft.device.dualscreen.testing.rules.foldableTestRule
 import com.microsoft.device.dualscreen.testing.runner.FoldableJUnit4ClassRunner
@@ -65,7 +63,6 @@ class SurfaceDuoBottomNavigationTest {
 
     @Test
     @DualScreenTest
-    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testDisplayPositionEnd() {
         arrangeButtonsAndCheckPosition(DisplayPosition.END)
     }
@@ -78,7 +75,6 @@ class SurfaceDuoBottomNavigationTest {
 
     @Test
     @DualScreenTest
-    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testButtonSplit0_5() {
         arrangeButtonsAndCheckPosition(0, 5, DisplayPosition.END)
     }
@@ -97,7 +93,6 @@ class SurfaceDuoBottomNavigationTest {
 
     @Test
     @DualScreenTest
-    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testButtonSplit5_0() {
         arrangeButtonsAndCheckPosition(0, 5, DisplayPosition.END)
     }
@@ -120,7 +115,6 @@ class SurfaceDuoBottomNavigationTest {
 
     @Test
     @DualScreenTest
-    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testSwipeRight() {
         onView(withId(R.id.nav_view)).perform(changeButtonArrangement(2, 3))
 
@@ -130,7 +124,6 @@ class SurfaceDuoBottomNavigationTest {
 
     @Test
     @DualScreenTest
-    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testMultipleSwipes() {
         onView(withId(R.id.nav_view)).perform(changeButtonArrangement(2, 3))
 
@@ -152,7 +145,6 @@ class SurfaceDuoBottomNavigationTest {
 
     @Test
     @DualScreenTest
-    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testTransparentBackground() {
         onView(withId(R.id.nav_view)).check(matches(areTabsOnScreen(DisplayPosition.DUAL)))
         onView(withId(R.id.nav_view)).check(matches(Matchers.not(hasHalfTransparentBackground())))

--- a/bottomnavigation/bottomnavigation/src/androidTest/java/com/microsoft/device/dualscreen/bottomnavigation/utils/TestUtils.kt
+++ b/bottomnavigation/bottomnavigation/src/androidTest/java/com/microsoft/device/dualscreen/bottomnavigation/utils/TestUtils.kt
@@ -12,9 +12,11 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.google.android.material.bottomnavigation.BottomNavigationMenuView
 import com.microsoft.device.dualscreen.bottomnavigation.BottomNavigationView
-import com.microsoft.device.dualscreen.testing.DeviceModel
+import com.microsoft.device.dualscreen.testing.getDeviceModel
 import com.microsoft.device.dualscreen.utils.wm.DisplayPosition
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -83,7 +85,8 @@ fun areTabsOnScreen(pos: DisplayPosition): Matcher<View> =
             val xStart = firstChild.translationX.toInt() + firstChild.left
             val xEnd = (lastChild.translationX + lastChild.left + lastChild.width).toInt()
 
-            with(DeviceModel.SurfaceDuo) {
+            val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            with(uiDevice.getDeviceModel()) {
                 return when (pos) {
                     DisplayPosition.DUAL ->
                         xStart in 0..paneWidth && xEnd in (paneWidth + foldWidth)..totalDisplay

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -147,7 +147,6 @@ ext {
     ]
 
     //Android test dependencies version
-    javaJunitVersion = "4.13.2"
     junitInstrumentationVersion = "1.1.3"
     espressoCoreVersion = "3.3.0"
     testRunnerVersion = "1.4.0"
@@ -161,7 +160,6 @@ ext {
     espressoContribVersion = "3.3.0"
 
     instrumentationTestDependencies = [
-            javaJunit              : "junit:junit:$javaJunitVersion",
             junit                  : "androidx.test.ext:junit:$junitInstrumentationVersion",
             junitKtx               : "androidx.test.ext:junit-ktx:$junitInstrumentationVersion",
             espressoCore           : "androidx.test.espresso:espresso-core:$espressoCoreVersion",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -149,8 +149,8 @@ ext {
     //Android test dependencies version
     junitInstrumentationVersion = "1.1.3"
     espressoCoreVersion = "3.3.0"
-    testRunnerVersion = "1.3.0"
-    testRulesVersion = "1.3.0"
+    testRunnerVersion = "1.4.0"
+    testRulesVersion = "1.4.0"
     uiAutomatorVersion = "2.2.0"
     supportTestRulesVersion = "1.0.2"
     fragmentTestingVersion = "1.3.1"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -147,6 +147,7 @@ ext {
     ]
 
     //Android test dependencies version
+    javaJunitVersion = "4.13.2"
     junitInstrumentationVersion = "1.1.3"
     espressoCoreVersion = "3.3.0"
     testRunnerVersion = "1.4.0"
@@ -160,6 +161,7 @@ ext {
     espressoContribVersion = "3.3.0"
 
     instrumentationTestDependencies = [
+            javaJunit              : "junit:junit:$javaJunitVersion",
             junit                  : "androidx.test.ext:junit:$junitInstrumentationVersion",
             junitKtx               : "androidx.test.ext:junit-ktx:$junitInstrumentationVersion",
             espressoCore           : "androidx.test.espresso:espresso-core:$espressoCoreVersion",

--- a/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FoldableLayoutDualScreenTestForSurfaceDuo.kt
+++ b/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FoldableLayoutDualScreenTestForSurfaceDuo.kt
@@ -5,39 +5,41 @@
 
 package com.microsoft.device.dualscreen.layouts
 
+import android.app.UiAutomation
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.ext.junit.rules.ActivityScenarioRule
-import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
+import androidx.test.ext.junit.rules.activityScenarioRule
 import com.microsoft.device.dualscreen.layouts.test.R
 import com.microsoft.device.dualscreen.layouts.utils.FoldableLayoutDualScreenActivity
+import com.microsoft.device.dualscreen.testing.DeviceModel
 import com.microsoft.device.dualscreen.testing.WindowLayoutInfoConsumer
-import com.microsoft.device.dualscreen.testing.resetOrientation
-import com.microsoft.device.dualscreen.testing.spanFromStart
+import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
+import com.microsoft.device.dualscreen.testing.filters.SingleScreenTest
+import com.microsoft.device.dualscreen.testing.filters.TargetDevice
+import com.microsoft.device.dualscreen.testing.rules.DualScreenTestRule
+import com.microsoft.device.dualscreen.testing.rules.foldableTestRule
+import com.microsoft.device.dualscreen.testing.runner.FoldableJUnit4ClassRunner
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4ClassRunner::class)
+@RunWith(FoldableJUnit4ClassRunner::class)
 class FoldableLayoutDualScreenTestForSurfaceDuo {
+    private val activityScenarioRule = activityScenarioRule<FoldableLayoutDualScreenActivity>()
+    private val dualScreenTestRule = DualScreenTestRule()
+    private val windowLayoutInfoConsumer = WindowLayoutInfoConsumer()
 
     @get:Rule
-    val activityScenarioRule = ActivityScenarioRule(FoldableLayoutDualScreenActivity::class.java)
-
-    private val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    private val windowLayoutInfoConsumer = WindowLayoutInfoConsumer()
+    val testRule: TestRule = foldableTestRule(activityScenarioRule, dualScreenTestRule)
 
     @Before
     fun before() {
-        uiDevice.resetOrientation()
-
         activityScenarioRule.scenario.onActivity {
             windowLayoutInfoConsumer.register(it)
         }
@@ -49,39 +51,31 @@ class FoldableLayoutDualScreenTestForSurfaceDuo {
     }
 
     @Test
+    @SingleScreenTest
     fun testLayoutSingleScreen() {
         onView(withId(R.id.textViewSingle)).check(matches(isDisplayed()))
         onView(withId(R.id.textViewSingle)).check(matches(withText(R.string.single_screen_mode)))
     }
 
     @Test
+    @SingleScreenTest(orientation = UiAutomation.ROTATION_FREEZE_270)
     fun testLayoutSingleScreenLandscape() {
-        windowLayoutInfoConsumer.resetWindowInfoLayoutCounter()
-        uiDevice.setOrientationRight()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         onView(withId(R.id.textViewSingle)).check(matches(isDisplayed()))
         onView(withId(R.id.textViewSingle)).check(matches(withText(R.string.single_screen_mode)))
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testLayoutDualScreenLandscape() {
-        windowLayoutInfoConsumer.resetWindowInfoLayoutCounter()
-        uiDevice.spanFromStart()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         onView(withId(R.id.textViewDual)).check(matches(isDisplayed()))
         onView(withId(R.id.textViewDual)).check(matches(withText(R.string.dual_portrait)))
     }
 
     @Test
+    @DualScreenTest(orientation = UiAutomation.ROTATION_FREEZE_270)
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testLayoutDualScreenPortrait() {
-        uiDevice.spanFromStart()
-
-        windowLayoutInfoConsumer.resetWindowInfoLayoutCounter()
-        uiDevice.setOrientationRight()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         onView(withId(R.id.textViewDual)).check(matches(isDisplayed()))
         onView(withId(R.id.textViewDual)).check(matches(withText(R.string.dual_landscape)))
     }

--- a/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FoldableLayoutSingleScreenTestForSurfaceDuo.kt
+++ b/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FoldableLayoutSingleScreenTestForSurfaceDuo.kt
@@ -80,10 +80,7 @@ class FoldableLayoutSingleScreenTestForSurfaceDuo {
             matches(
                 isViewOnScreen(
                     position = DisplayPosition.START,
-                    orientation = ORIENTATION_LANDSCAPE,
-                    firstDisplay = DeviceModel.SurfaceDuo.paneWidth,
-                    totalDisplay = DeviceModel.SurfaceDuo.totalDisplay,
-                    foldingFeature = DeviceModel.SurfaceDuo.foldWidth
+                    orientation = ORIENTATION_LANDSCAPE
                 )
             )
         )
@@ -94,10 +91,7 @@ class FoldableLayoutSingleScreenTestForSurfaceDuo {
             matches(
                 isViewOnScreen(
                     position = DisplayPosition.END,
-                    orientation = ORIENTATION_LANDSCAPE,
-                    firstDisplay = DeviceModel.SurfaceDuo.paneWidth,
-                    totalDisplay = DeviceModel.SurfaceDuo.totalDisplay,
-                    foldingFeature = DeviceModel.SurfaceDuo.foldWidth
+                    orientation = ORIENTATION_LANDSCAPE
                 )
             )
         )
@@ -115,10 +109,7 @@ class FoldableLayoutSingleScreenTestForSurfaceDuo {
             matches(
                 isViewOnScreen(
                     position = DisplayPosition.START,
-                    orientation = ORIENTATION_PORTRAIT,
-                    firstDisplay = DeviceModel.SurfaceDuo.paneWidth,
-                    totalDisplay = DeviceModel.SurfaceDuo.totalDisplay,
-                    foldingFeature = DeviceModel.SurfaceDuo.foldWidth
+                    orientation = ORIENTATION_PORTRAIT
                 )
             )
         )
@@ -129,10 +120,7 @@ class FoldableLayoutSingleScreenTestForSurfaceDuo {
             matches(
                 isViewOnScreen(
                     position = DisplayPosition.END,
-                    orientation = ORIENTATION_PORTRAIT,
-                    firstDisplay = DeviceModel.SurfaceDuo.paneWidth,
-                    totalDisplay = DeviceModel.SurfaceDuo.totalDisplay,
-                    foldingFeature = DeviceModel.SurfaceDuo.foldWidth
+                    orientation = ORIENTATION_PORTRAIT
                 )
             )
         )

--- a/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FoldableLayoutTestOnSecondActivityForSurfaceDuo.kt
+++ b/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FoldableLayoutTestOnSecondActivityForSurfaceDuo.kt
@@ -5,45 +5,48 @@
 
 package com.microsoft.device.dualscreen.layouts
 
+import android.app.UiAutomation
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.filters.LargeTest
-import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import com.google.common.truth.Truth.assertThat
 import com.microsoft.device.dualscreen.layouts.test.R
 import com.microsoft.device.dualscreen.layouts.utils.FoldableLayoutTestOnSecondActivity
 import com.microsoft.device.dualscreen.testing.CurrentActivityDelegate
+import com.microsoft.device.dualscreen.testing.DeviceModel
 import com.microsoft.device.dualscreen.testing.ForceClick
 import com.microsoft.device.dualscreen.testing.WindowLayoutInfoConsumer
-import com.microsoft.device.dualscreen.testing.resetOrientation
-import com.microsoft.device.dualscreen.testing.spanFromStart
+import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
+import com.microsoft.device.dualscreen.testing.filters.SingleScreenTest
+import com.microsoft.device.dualscreen.testing.filters.TargetDevice
+import com.microsoft.device.dualscreen.testing.rules.DualScreenTestRule
+import com.microsoft.device.dualscreen.testing.rules.foldableTestRule
+import com.microsoft.device.dualscreen.testing.runner.FoldableJUnit4ClassRunner
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 
 @LargeTest
-@RunWith(AndroidJUnit4ClassRunner::class)
+@RunWith(FoldableJUnit4ClassRunner::class)
 class FoldableLayoutTestOnSecondActivityForSurfaceDuo {
-    @get:Rule
-    val activityScenarioRule = ActivityScenarioRule(FoldableLayoutTestOnSecondActivity::class.java)
-
-    private val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    private val activityScenarioRule = activityScenarioRule<FoldableLayoutTestOnSecondActivity>()
+    private val dualScreenTestRule = DualScreenTestRule()
     private val windowLayoutInfoConsumer = WindowLayoutInfoConsumer()
     private val currentActivityDelegate = CurrentActivityDelegate()
 
+    @get:Rule
+    val testRule: TestRule = foldableTestRule(activityScenarioRule, dualScreenTestRule)
+
     @Before
     fun before() {
-        uiDevice.resetOrientation()
-
         currentActivityDelegate.setup(activityScenarioRule)
         activityScenarioRule.scenario.onActivity {
             windowLayoutInfoConsumer.register(it)
@@ -57,6 +60,7 @@ class FoldableLayoutTestOnSecondActivityForSurfaceDuo {
     }
 
     @Test
+    @SingleScreenTest
     fun testLayoutSingleScreen() {
         currentActivityDelegate.resetActivityCounter()
         onView(withId(R.id.start)).perform(click())
@@ -71,11 +75,8 @@ class FoldableLayoutTestOnSecondActivityForSurfaceDuo {
     }
 
     @Test
+    @SingleScreenTest(orientation = UiAutomation.ROTATION_FREEZE_270)
     fun testLayoutSingleScreenLandscape() {
-        windowLayoutInfoConsumer.resetWindowInfoLayoutCounter()
-        uiDevice.setOrientationRight()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         currentActivityDelegate.resetActivityCounter()
         onView(withId(R.id.start)).perform(ForceClick())
         currentActivityDelegate.waitForActivity()
@@ -91,9 +92,9 @@ class FoldableLayoutTestOnSecondActivityForSurfaceDuo {
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testLayoutDualScreenLandscape() {
-        uiDevice.spanFromStart()
-
         currentActivityDelegate.resetActivityCounter()
         onView(withId(R.id.start)).perform(click())
         currentActivityDelegate.waitForActivity()
@@ -111,10 +112,9 @@ class FoldableLayoutTestOnSecondActivityForSurfaceDuo {
     }
 
     @Test
+    @DualScreenTest(orientation = UiAutomation.ROTATION_FREEZE_270)
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testLayoutDualScreenPortrait() {
-        uiDevice.spanFromStart()
-        uiDevice.setOrientationRight()
-
         currentActivityDelegate.resetActivityCounter()
         onView(withId(R.id.start)).perform(ForceClick())
         currentActivityDelegate.waitForActivity()

--- a/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FrameLayoutTestForSurfaceDuo.kt
+++ b/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/FrameLayoutTestForSurfaceDuo.kt
@@ -8,40 +8,38 @@ package com.microsoft.device.dualscreen.layouts
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.filters.SmallTest
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import com.microsoft.device.dualscreen.layouts.test.R
 import com.microsoft.device.dualscreen.layouts.utils.FrameLayoutActivity
 import com.microsoft.device.dualscreen.layouts.utils.changeDisplayPosition
 import com.microsoft.device.dualscreen.layouts.utils.isFrameLayoutOnScreen
 import com.microsoft.device.dualscreen.testing.WindowLayoutInfoConsumer
-import com.microsoft.device.dualscreen.testing.resetOrientation
-import com.microsoft.device.dualscreen.testing.spanFromStart
+import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
+import com.microsoft.device.dualscreen.testing.rules.DualScreenTestRule
+import com.microsoft.device.dualscreen.testing.rules.foldableTestRule
 import com.microsoft.device.dualscreen.utils.wm.DisplayPosition
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 
 @SmallTest
 @RunWith(AndroidJUnit4ClassRunner::class)
 class FrameLayoutTestForSurfaceDuo {
+    private val activityScenarioRule = activityScenarioRule<FrameLayoutActivity>()
+    private val dualScreenTestRule = DualScreenTestRule()
+    private val windowLayoutInfoConsumer = WindowLayoutInfoConsumer()
 
     @get:Rule
-    val activityTestRule = ActivityScenarioRule(FrameLayoutActivity::class.java)
-
-    private val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    private val windowLayoutInfoConsumer = WindowLayoutInfoConsumer()
+    val testRule: TestRule = foldableTestRule(activityScenarioRule, dualScreenTestRule)
 
     @Before
     fun before() {
-        uiDevice.resetOrientation()
-
-        activityTestRule.scenario.onActivity {
+        activityScenarioRule.scenario.onActivity {
             windowLayoutInfoConsumer.register(it)
         }
     }
@@ -52,21 +50,15 @@ class FrameLayoutTestForSurfaceDuo {
     }
 
     @Test
+    @DualScreenTest
     fun testDisplayPositionFromLayout() {
-        windowLayoutInfoConsumer.resetWindowInfoLayoutCounter()
-        uiDevice.spanFromStart()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         onView(withId(R.id.duo_wrapper))
             .check(matches(isFrameLayoutOnScreen(DisplayPosition.DUAL)))
     }
 
     @Test
+    @DualScreenTest
     fun testDisplayPositionEnd() {
-        windowLayoutInfoConsumer.resetWindowInfoLayoutCounter()
-        uiDevice.spanFromStart()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         onView(withId(R.id.duo_wrapper))
             .perform(changeDisplayPosition(DisplayPosition.END))
         onView(withId(R.id.duo_wrapper))
@@ -74,11 +66,8 @@ class FrameLayoutTestForSurfaceDuo {
     }
 
     @Test
+    @DualScreenTest
     fun testDisplayPositionDual() {
-        windowLayoutInfoConsumer.resetWindowInfoLayoutCounter()
-        uiDevice.spanFromStart()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         onView(withId(R.id.duo_wrapper))
             .perform(changeDisplayPosition(DisplayPosition.DUAL))
         onView(withId(R.id.duo_wrapper))
@@ -86,11 +75,8 @@ class FrameLayoutTestForSurfaceDuo {
     }
 
     @Test
+    @DualScreenTest
     fun testDisplayPositionStart() {
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-        uiDevice.spanFromStart()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         onView(withId(R.id.duo_wrapper))
             .perform(changeDisplayPosition(DisplayPosition.START))
         onView(withId(R.id.duo_wrapper))

--- a/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/utils/TestUtils.kt
+++ b/layouts/layouts/src/androidTest/java/com/microsoft/device/dualscreen/layouts/utils/TestUtils.kt
@@ -10,9 +10,11 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.microsoft.device.dualscreen.layouts.FoldableFrameLayout
-import com.microsoft.device.dualscreen.testing.DeviceModel
 import com.microsoft.device.dualscreen.testing.areCoordinatesOnTargetScreen
+import com.microsoft.device.dualscreen.testing.getDeviceModel
 import com.microsoft.device.dualscreen.utils.wm.DisplayPosition
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -52,13 +54,17 @@ fun isFrameLayoutOnScreen(pos: DisplayPosition): Matcher<View> =
             val child = item.getChildAt(0) ?: return false
             val startArray = IntArray(2)
             child.getLocationInWindow(startArray)
-            return areCoordinatesOnTargetScreen(
-                targetScreenPosition = pos,
-                start = startArray[0],
-                end = startArray[0] + child.width,
-                firstDisplay = DeviceModel.SurfaceDuo.paneWidth,
-                totalDisplay = DeviceModel.SurfaceDuo.totalDisplay,
-                foldingFeature = DeviceModel.SurfaceDuo.foldWidth
-            )
+
+            val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            with(uiDevice.getDeviceModel()) {
+                return areCoordinatesOnTargetScreen(
+                    targetScreenPosition = pos,
+                    start = startArray[0],
+                    end = startArray[0] + child.width,
+                    firstDisplay = paneWidth,
+                    totalDisplay = totalDisplay,
+                    foldingFeature = foldWidth
+                )
+            }
         }
     }

--- a/navigation/navigation-common/src/androidTest/java/com/microsoft/device/dualscreen/navigation/FragmentExtensionsTests.kt
+++ b/navigation/navigation-common/src/androidTest/java/com/microsoft/device/dualscreen/navigation/FragmentExtensionsTests.kt
@@ -8,35 +8,37 @@ package com.microsoft.device.dualscreen.navigation
 import androidx.navigation.foldableNavOptions
 import androidx.navigation.testutils.EmptyFragment
 import androidx.test.ext.junit.rules.activityScenarioRule
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import com.google.common.truth.Truth.assertThat
 import com.microsoft.device.dualscreen.navigation.utils.SimpleFragmentBackStackListener
 import com.microsoft.device.dualscreen.navigation.utils.SurfaceDuoSimpleActivity
 import com.microsoft.device.dualscreen.navigation.utils.runWithBackStackListener
 import com.microsoft.device.dualscreen.testing.CurrentActivityDelegate
 import com.microsoft.device.dualscreen.testing.WindowLayoutInfoConsumer
-import com.microsoft.device.dualscreen.testing.spanFromStart
+import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
+import com.microsoft.device.dualscreen.testing.rules.DualScreenTestRule
+import com.microsoft.device.dualscreen.testing.rules.foldableTestRule
+import com.microsoft.device.dualscreen.testing.runner.FoldableJUnit4ClassRunner
 import com.microsoft.device.dualscreen.utils.wm.ScreenMode
 import com.microsoft.device.dualscreen.utils.wm.screenMode
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 
 @MediumTest
-@RunWith(AndroidJUnit4::class)
+@RunWith(FoldableJUnit4ClassRunner::class)
 class FragmentExtensionsTests {
-    @get:Rule
-    val activityScenarioRule = activityScenarioRule<SurfaceDuoSimpleActivity>()
-    private val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-
+    private val activityScenarioRule = activityScenarioRule<SurfaceDuoSimpleActivity>()
+    private val dualScreenTestRule = DualScreenTestRule()
+    private val windowLayoutInfoConsumer = WindowLayoutInfoConsumer()
     private val fragmentBackStackListener = SimpleFragmentBackStackListener()
     private val currentActivityDelegate = CurrentActivityDelegate()
-    private val windowLayoutInfoConsumer = WindowLayoutInfoConsumer()
+
+    @get:Rule
+    val testRule: TestRule = foldableTestRule(activityScenarioRule, dualScreenTestRule)
 
     @Before
     fun setup() {
@@ -53,11 +55,8 @@ class FragmentExtensionsTests {
     }
 
     @Test
+    @DualScreenTest
     fun testIsOnStartContainer() {
-        windowLayoutInfoConsumer.reset()
-        uiDevice.spanFromStart()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         assertThat(currentActivityDelegate.currentActivity).isNotNull()
 
         currentActivityDelegate.runWithBackStackListener(fragmentBackStackListener) {
@@ -83,11 +82,8 @@ class FragmentExtensionsTests {
     }
 
     @Test
+    @DualScreenTest
     fun testIsOnEndContainer() {
-        windowLayoutInfoConsumer.reset()
-        uiDevice.spanFromStart()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         assertThat(currentActivityDelegate.currentActivity).isNotNull()
 
         currentActivityDelegate.runWithBackStackListener(fragmentBackStackListener) {

--- a/screenmanager/tests/build.gradle
+++ b/screenmanager/tests/build.gradle
@@ -39,6 +39,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    configurations.all {
+        resolutionStrategy.force 'androidx.test:runner:1.3.0'
+    }
 }
 
 dependencies {

--- a/snackbar/snackbar/src/androidTest/java/com/microsoft/device/dualscreen/snackbar/SnackbarContainerLandscapeTests.kt
+++ b/snackbar/snackbar/src/androidTest/java/com/microsoft/device/dualscreen/snackbar/SnackbarContainerLandscapeTests.kt
@@ -5,31 +5,25 @@
 
 package com.microsoft.device.dualscreen.snackbar
 
+import android.app.UiAutomation
 import androidx.test.filters.MediumTest
-import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.microsoft.device.dualscreen.snackbar.SnackbarPosition.BOTH
 import com.microsoft.device.dualscreen.snackbar.SnackbarPosition.END
 import com.microsoft.device.dualscreen.snackbar.SnackbarPosition.START
 import com.microsoft.device.dualscreen.snackbar.test.R
+import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
+import com.microsoft.device.dualscreen.testing.filters.SingleScreenTest
 import com.microsoft.device.dualscreen.testing.getDeviceModel
-import com.microsoft.device.dualscreen.testing.resetOrientation
-import com.microsoft.device.dualscreen.testing.spanFromStart
-import org.junit.After
+import com.microsoft.device.dualscreen.testing.runner.FoldableJUnit4ClassRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @MediumTest
-@RunWith(AndroidJUnit4ClassRunner::class)
+@RunWith(FoldableJUnit4ClassRunner::class)
 class SnackbarContainerLandscapeTests : SnackbarContainerTests() {
-    @After
-    fun resetOrientation() {
-        uiDevice.resetOrientation()
-    }
-
     @Test
+    @SingleScreenTest(orientation = UiAutomation.ROTATION_FREEZE_270)
     fun testPositionOnSingleScreen() {
-        uiDevice.setOrientationRight()
-
         val margin = SnackbarContainer.COORDINATOR_LAYOUT_MARGIN
         testMargins(TestParams(R.string.snackbar_to_start, START, margin, 0, margin, margin))
         testMargins(TestParams(R.string.snackbar_to_end, END, margin, 0, margin, margin))
@@ -37,12 +31,8 @@ class SnackbarContainerLandscapeTests : SnackbarContainerTests() {
     }
 
     @Test
+    @DualScreenTest(orientation = UiAutomation.ROTATION_FREEZE_270)
     fun testPositionOnDualScreen() {
-        windowLayoutInfoConsumer.reset()
-        uiDevice.spanFromStart()
-        uiDevice.setOrientationRight()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         val margin = SnackbarContainer.COORDINATOR_LAYOUT_MARGIN
         val bottomMargin = with(uiDevice.getDeviceModel()) {
             paneWidth + foldWidth + margin

--- a/snackbar/snackbar/src/androidTest/java/com/microsoft/device/dualscreen/snackbar/SnackbarContainerPortraitTests.kt
+++ b/snackbar/snackbar/src/androidTest/java/com/microsoft/device/dualscreen/snackbar/SnackbarContainerPortraitTests.kt
@@ -11,8 +11,9 @@ import com.microsoft.device.dualscreen.snackbar.SnackbarPosition.BOTH
 import com.microsoft.device.dualscreen.snackbar.SnackbarPosition.END
 import com.microsoft.device.dualscreen.snackbar.SnackbarPosition.START
 import com.microsoft.device.dualscreen.snackbar.test.R
+import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
+import com.microsoft.device.dualscreen.testing.filters.SingleScreenTest
 import com.microsoft.device.dualscreen.testing.getDeviceModel
-import com.microsoft.device.dualscreen.testing.spanFromStart
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -21,6 +22,7 @@ import org.junit.runner.RunWith
 class SnackbarContainerPortraitTests : SnackbarContainerTests() {
 
     @Test
+    @SingleScreenTest
     fun testPositionOnSingleScreen() {
         val margin = SnackbarContainer.COORDINATOR_LAYOUT_MARGIN
         testMargins(TestParams(R.string.snackbar_to_start, START, margin, 0, margin, margin))
@@ -29,11 +31,8 @@ class SnackbarContainerPortraitTests : SnackbarContainerTests() {
     }
 
     @Test
+    @DualScreenTest
     fun testPositionOnDualScreen() {
-        windowLayoutInfoConsumer.reset()
-        uiDevice.spanFromStart()
-        windowLayoutInfoConsumer.waitForWindowInfoLayoutChanges()
-
         val margin = SnackbarContainer.COORDINATOR_LAYOUT_MARGIN
         val rightMargin = with(uiDevice.getDeviceModel()) {
             paneWidth - margin

--- a/snackbar/snackbar/src/androidTest/java/com/microsoft/device/dualscreen/snackbar/SnackbarContainerTests.kt
+++ b/snackbar/snackbar/src/androidTest/java/com/microsoft/device/dualscreen/snackbar/SnackbarContainerTests.kt
@@ -16,15 +16,21 @@ import com.microsoft.device.dualscreen.snackbar.test.R
 import com.microsoft.device.dualscreen.snackbar.utils.SampleActivity
 import com.microsoft.device.dualscreen.snackbar.utils.hasMargins
 import com.microsoft.device.dualscreen.testing.WindowLayoutInfoConsumer
+import com.microsoft.device.dualscreen.testing.rules.DualScreenTestRule
+import com.microsoft.device.dualscreen.testing.rules.foldableTestRule
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
+import org.junit.rules.TestRule
 
 open class SnackbarContainerTests {
-    @get:Rule
-    val activityScenarioRule = activityScenarioRule<SampleActivity>()
+    private val activityScenarioRule = activityScenarioRule<SampleActivity>()
+    private val dualScreenTestRule = DualScreenTestRule()
     protected val uiDevice: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     protected val windowLayoutInfoConsumer = WindowLayoutInfoConsumer()
+
+    @get:Rule
+    val testRule: TestRule = foldableTestRule(activityScenarioRule, dualScreenTestRule)
 
     @Before
     fun setup() {

--- a/tabs/tabs/build.gradle
+++ b/tabs/tabs/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     testImplementation testDependencies.junit
 
     androidTestImplementation project(':utils:test-utils')
-    androidTestImplementation instrumentationTestDependencies.junit
+    androidTestImplementation instrumentationTestDependencies.junitKtx
     androidTestImplementation commonDependencies.mockitoCore
     androidTestImplementation commonDependencies.mockitoDexMaker
     androidTestImplementation instrumentationTestDependencies.uiAutomator

--- a/tabs/tabs/src/androidTest/java/com/microsoft/device/dualscreen/tabs/SurfaceDuoTabLayoutTest.kt
+++ b/tabs/tabs/src/androidTest/java/com/microsoft/device/dualscreen/tabs/SurfaceDuoTabLayoutTest.kt
@@ -10,9 +10,8 @@ import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.espresso.action.ViewActions.swipeRight
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.filters.MediumTest
-import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.microsoft.device.dualscreen.tabs.test.R
@@ -22,79 +21,91 @@ import com.microsoft.device.dualscreen.tabs.utils.changeButtonArrangement
 import com.microsoft.device.dualscreen.tabs.utils.changeDisplayPosition
 import com.microsoft.device.dualscreen.tabs.utils.checkChildCount
 import com.microsoft.device.dualscreen.tabs.utils.hasHalfTransparentBackground
+import com.microsoft.device.dualscreen.testing.DeviceModel
+import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
+import com.microsoft.device.dualscreen.testing.filters.TargetDevice
+import com.microsoft.device.dualscreen.testing.rules.DualScreenTestRule
+import com.microsoft.device.dualscreen.testing.runner.FoldableJUnit4ClassRunner
 import com.microsoft.device.dualscreen.testing.spanFromStart
 import com.microsoft.device.dualscreen.utils.wm.DisplayPosition
 import org.hamcrest.Matchers.not
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @MediumTest
-@RunWith(AndroidJUnit4ClassRunner::class)
+@RunWith(FoldableJUnit4ClassRunner::class)
 class SurfaceDuoTabLayoutTest {
 
+    private val activityScenarioRule = activityScenarioRule<SimpleTabActivity>()
+
     @get:Rule
-    val activityTestRule = ActivityScenarioRule(SimpleTabActivity::class.java)
+    var ruleChain: RuleChain =
+        RuleChain.outerRule(activityScenarioRule).around(DualScreenTestRule())
     private val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
     @Test
+    @DualScreenTest
     fun testDisplayPositionFromLayout() {
-        uiDevice.spanFromStart()
         onView(withId(R.id.tabs)).check(matches(areTabsOnScreen(DisplayPosition.DUAL)))
     }
 
     @Test
+    @DualScreenTest
     fun testDisplayPositionStart() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(DisplayPosition.START)
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testDisplayPositionEnd() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(DisplayPosition.END)
     }
 
     @Test
+    @DualScreenTest
     fun testDisplayPositionDual() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(DisplayPosition.DUAL)
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testButtonSplit0_5() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(0, 5, DisplayPosition.END)
     }
 
     @Test
+    @DualScreenTest
     fun testButtonSplit1_4() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(1, 4, DisplayPosition.DUAL)
     }
 
     @Test
+    @DualScreenTest
     fun testButtonSplit2_3() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(2, 3, DisplayPosition.DUAL)
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testButtonSplit5_0() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(0, 5, DisplayPosition.END)
     }
 
     @Test
+    @DualScreenTest
     fun testButtonSplit_invalid() {
-        uiDevice.spanFromStart()
         arrangeButtonsAndCheckPosition(5, 0, DisplayPosition.START)
         arrangeButtonsAndCheckPosition(5, 5, DisplayPosition.START)
     }
 
     @Test
+    @DualScreenTest
     fun testSwipeLeft() {
-        uiDevice.spanFromStart()
         onView(withId(R.id.tabs)).perform(changeButtonArrangement(2, 3))
 
         onView(withId(R.id.tabs)).perform(swipeLeft())
@@ -102,8 +113,9 @@ class SurfaceDuoTabLayoutTest {
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testSwipeRight() {
-        uiDevice.spanFromStart()
         onView(withId(R.id.tabs)).perform(changeButtonArrangement(3, 2))
 
         onView(withId(R.id.tabs)).perform(swipeRight())
@@ -111,8 +123,9 @@ class SurfaceDuoTabLayoutTest {
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testMultipleSwipes() {
-        uiDevice.spanFromStart()
         onView(withId(R.id.tabs)).perform(changeButtonArrangement(2, 3))
 
         onView(withId(R.id.tabs)).perform(swipeLeft())
@@ -148,8 +161,9 @@ class SurfaceDuoTabLayoutTest {
     }
 
     @Test
+    @DualScreenTest
+    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testTransparentBackground() {
-        uiDevice.spanFromStart()
         onView(withId(R.id.tabs)).check(matches(areTabsOnScreen(DisplayPosition.DUAL)))
         onView(withId(R.id.tabs)).check(matches(not(hasHalfTransparentBackground())))
 

--- a/tabs/tabs/src/androidTest/java/com/microsoft/device/dualscreen/tabs/SurfaceDuoTabLayoutTest.kt
+++ b/tabs/tabs/src/androidTest/java/com/microsoft/device/dualscreen/tabs/SurfaceDuoTabLayoutTest.kt
@@ -72,7 +72,6 @@ class SurfaceDuoTabLayoutTest {
 
     @Test
     @DualScreenTest
-    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testButtonSplit0_5() {
         arrangeButtonsAndCheckPosition(0, 5, DisplayPosition.END)
     }
@@ -91,7 +90,6 @@ class SurfaceDuoTabLayoutTest {
 
     @Test
     @DualScreenTest
-    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testButtonSplit5_0() {
         arrangeButtonsAndCheckPosition(0, 5, DisplayPosition.END)
     }
@@ -114,7 +112,6 @@ class SurfaceDuoTabLayoutTest {
 
     @Test
     @DualScreenTest
-    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testSwipeRight() {
         onView(withId(R.id.tabs)).perform(changeButtonArrangement(3, 2))
 
@@ -124,7 +121,6 @@ class SurfaceDuoTabLayoutTest {
 
     @Test
     @DualScreenTest
-    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testMultipleSwipes() {
         onView(withId(R.id.tabs)).perform(changeButtonArrangement(2, 3))
 
@@ -162,7 +158,6 @@ class SurfaceDuoTabLayoutTest {
 
     @Test
     @DualScreenTest
-    @TargetDevice(device = DeviceModel.SurfaceDuo)
     fun testTransparentBackground() {
         onView(withId(R.id.tabs)).check(matches(areTabsOnScreen(DisplayPosition.DUAL)))
         onView(withId(R.id.tabs)).check(matches(not(hasHalfTransparentBackground())))

--- a/tabs/tabs/src/androidTest/java/com/microsoft/device/dualscreen/tabs/utils/TestUtils.kt
+++ b/tabs/tabs/src/androidTest/java/com/microsoft/device/dualscreen/tabs/utils/TestUtils.kt
@@ -12,8 +12,10 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.microsoft.device.dualscreen.tabs.TabLayout
-import com.microsoft.device.dualscreen.testing.DeviceModel
+import com.microsoft.device.dualscreen.testing.getDeviceModel
 import com.microsoft.device.dualscreen.utils.wm.DisplayPosition
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -83,7 +85,8 @@ fun areTabsOnScreen(pos: DisplayPosition): Matcher<View> =
             val xStart = startArray[0]
             val xEnd = endArray[0] + lastTab.width
 
-            with(DeviceModel.SurfaceDuo) {
+            val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            with(uiDevice.getDeviceModel()) {
                 return when (pos) {
                     DisplayPosition.DUAL ->
                         xStart in 0..paneWidth && xEnd in (paneWidth + foldWidth)..totalDisplay

--- a/utils/test-utils/build.gradle
+++ b/utils/test-utils/build.gradle
@@ -49,6 +49,7 @@ android {
 
 dependencies {
     implementation project(':utils:wm-utils')
+    implementation instrumentationTestDependencies.javaJunit
     implementation androidxDependencies.coreKtx
     implementation androidxDependencies.appCompat
     implementation androidxDependencies.windowManager

--- a/utils/test-utils/build.gradle
+++ b/utils/test-utils/build.gradle
@@ -49,7 +49,7 @@ android {
 
 dependencies {
     implementation project(':utils:wm-utils')
-    implementation instrumentationTestDependencies.javaJunit
+    implementation testDependencies.junit
     implementation androidxDependencies.coreKtx
     implementation androidxDependencies.appCompat
     implementation androidxDependencies.windowManager

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/CurrentActivityDelegate.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/CurrentActivityDelegate.kt
@@ -51,6 +51,7 @@ class CurrentActivityDelegate {
      */
     fun <T : Activity> setup(activityScenarioRule: ActivityScenarioRule<T>) {
         activityScenarioRule.scenario.onActivity {
+            _currentActivity = it
             it.application.registerActivityLifecycleCallbacks(activityLifecycleCallback)
         }
     }

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/DeviceModel.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/DeviceModel.kt
@@ -38,8 +38,8 @@ import androidx.test.uiautomator.UiDevice
  * @param closeSteps: number of move steps to take when executing a close gesture, where one step takes ~ 5ms
  */
 enum class DeviceModel(
-    val paneWidth: Int,
-    val paneHeight: Int,
+    var paneWidth: Int,
+    var paneHeight: Int,
     val foldWidth: Int,
     val leftX: Int = paneWidth / 2,
     val rightX: Int = leftX + paneWidth + foldWidth,
@@ -109,5 +109,8 @@ private fun UiDevice.getModelFromPaneWidth(paneWidth: Int): DeviceModel {
         "DeviceModel",
         "Unknown dualscreen device dimensions $displayWidth $displayHeight"
     )
-    return DeviceModel.Other
+    return DeviceModel.Other.apply {
+        this.paneWidth = displayWidth / 2
+        this.paneHeight = displayHeight
+    }
 }

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/DeviceModel.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/DeviceModel.kt
@@ -24,8 +24,8 @@ import androidx.test.uiautomator.UiDevice
  * For Microsoft Surface Duo devices, the coordinates are all from the dual portrait point of view, and dimensions
  * were taken from here: https://docs.microsoft.com/dual-screen/android/surface-duo-dimensions
  *
- * @param paneWidth: width of device panes in pixels in dual portrait mode (assumed to have panes of equal size)
- * @param paneHeight: height of device panes in pixels in dual portrait mode (assumed to have panes of equal size)
+ * @param paneWidth_: width of device panes in pixels in dual portrait mode (assumed to have panes of equal size)
+ * @param paneHeight_: height of device panes in pixels in dual portrait mode (assumed to have panes of equal size)
  * @param foldWidth: width of device foldingFeature in pixels in dual portrait mode
  * @param leftX: x-coordinate of the center of the left pane in dual portrait mode
  * @param rightX: x-coordinate of the center of the right pane in dual portrait mode
@@ -38,23 +38,29 @@ import androidx.test.uiautomator.UiDevice
  * @param closeSteps: number of move steps to take when executing a close gesture, where one step takes ~ 5ms
  */
 enum class DeviceModel(
-    var paneWidth: Int,
-    var paneHeight: Int,
+    internal var paneWidth_: Int,
+    internal var paneHeight_: Int,
     val foldWidth: Int,
-    val leftX: Int = paneWidth / 2,
-    val rightX: Int = leftX + paneWidth + foldWidth,
-    val middleX: Int = paneWidth + foldWidth / 2,
-    val middleY: Int = paneHeight / 2,
+    val leftX: Int = paneWidth_ / 2,
+    val rightX: Int = leftX + paneWidth_ + foldWidth,
+    val middleX: Int = paneWidth_ + foldWidth / 2,
+    val middleY: Int = paneHeight_ / 2,
     val bottomY: Int,
     val spanSteps: Int = 400,
     val unspanSteps: Int = 200,
     val switchSteps: Int = 100,
     val closeSteps: Int = 50,
-    val totalDisplay: Int = paneWidth * 2 + foldWidth
+    val totalDisplay: Int = paneWidth_ * 2 + foldWidth
 ) {
-    SurfaceDuo(paneWidth = 1350, paneHeight = 1800, foldWidth = 84, bottomY = 1780),
-    SurfaceDuo2(paneWidth = 1344, paneHeight = 1892, foldWidth = 66, bottomY = 1870),
-    Other(paneWidth = 0, paneHeight = 0, foldWidth = 0, bottomY = 0);
+    SurfaceDuo(paneWidth_ = 1350, paneHeight_ = 1800, foldWidth = 84, bottomY = 1780),
+    SurfaceDuo2(paneWidth_ = 1344, paneHeight_ = 1892, foldWidth = 66, bottomY = 1870),
+    Other(paneWidth_ = 0, paneHeight_ = 0, foldWidth = 0, bottomY = 0);
+
+    val paneWidth: Int
+        get() = paneWidth_
+
+    val paneHeight: Int
+        get() = paneHeight_
 
     override fun toString(): String {
         return "$name [leftX: $leftX rightX: $rightX middleX: $middleX middleY: $middleY bottomY: $bottomY]"
@@ -110,7 +116,7 @@ private fun UiDevice.getModelFromPaneWidth(paneWidth: Int): DeviceModel {
         "Unknown dualscreen device dimensions $displayWidth $displayHeight"
     )
     return DeviceModel.Other.apply {
-        this.paneWidth = displayWidth / 2
-        this.paneHeight = displayHeight
+        this.paneWidth_ = displayWidth / 2
+        this.paneHeight_ = displayHeight
     }
 }

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/DeviceModel.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/DeviceModel.kt
@@ -50,7 +50,7 @@ enum class DeviceModel(
     val unspanSteps: Int = 200,
     val switchSteps: Int = 100,
     val closeSteps: Int = 50,
-    val totalDisplay: Int = paneWidth_ * 2 + foldWidth
+    internal var totalDisplay_: Int = paneWidth_ * 2 + foldWidth
 ) {
     SurfaceDuo(paneWidth_ = 1350, paneHeight_ = 1800, foldWidth = 84, bottomY = 1780),
     SurfaceDuo2(paneWidth_ = 1344, paneHeight_ = 1892, foldWidth = 66, bottomY = 1870),
@@ -61,6 +61,9 @@ enum class DeviceModel(
 
     val paneHeight: Int
         get() = paneHeight_
+
+    val totalDisplay: Int
+        get() = totalDisplay_
 
     override fun toString(): String {
         return "$name [leftX: $leftX rightX: $rightX middleX: $middleX middleY: $middleY bottomY: $bottomY]"
@@ -118,5 +121,6 @@ private fun UiDevice.getModelFromPaneWidth(paneWidth: Int): DeviceModel {
     return DeviceModel.Other.apply {
         this.paneWidth_ = displayWidth / 2
         this.paneHeight_ = displayHeight
+        this.totalDisplay_ = paneWidth_ * 2 + foldWidth
     }
 }

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/ViewMatcher.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/ViewMatcher.kt
@@ -7,6 +7,8 @@ package com.microsoft.device.dualscreen.testing
 
 import android.content.res.Configuration
 import android.view.View
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.microsoft.device.dualscreen.utils.wm.DisplayPosition
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -66,6 +68,24 @@ fun isViewOnScreen(
             )
         }
     }
+
+/**
+ * Returns a Matcher that checks if a View is shown in the display area given its position
+ * and screen dimensions.
+ *
+ * @param position: target position.
+ * @param orientation: orientation of the display. See Configuration {@see Configuration}.
+ * @return
+ */
+fun isViewOnScreen(
+    position: DisplayPosition,
+    orientation: Int,
+): Matcher<View> {
+    val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    with(uiDevice.getDeviceModel()) {
+        return isViewOnScreen(position, orientation, paneWidth, totalDisplay, foldWidth)
+    }
+}
 
 /**
  * Checks whether a specific screen-position is the screen defined by {@param start}, {@param end},

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/DeviceOrientation.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/DeviceOrientation.kt
@@ -1,3 +1,8 @@
+/*
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License.
+ */
+
 package com.microsoft.device.dualscreen.testing.filters
 
 /**

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/DeviceOrientation.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/DeviceOrientation.kt
@@ -1,0 +1,11 @@
+package com.microsoft.device.dualscreen.testing.filters
+
+/**
+ * Test classes or test methods annotated with @DeviceOrientation,
+ * will rotate the device or emulator depending on the given orientation.
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DeviceOrientation(
+    val orientation: Int = Int.MIN_VALUE
+)

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/DualScreenTest.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/DualScreenTest.kt
@@ -5,10 +5,8 @@
 
 package com.microsoft.device.dualscreen.testing.filters
 
-import org.junit.Test
-
 /**
- * Methods annotated with @[Test] that are also annotated with @DualScreenTest,
+ * Test classes or test methods annotated with @DualScreenTest,
  * will span the app to the entire display area
  * and will rotate the device or emulator depending on the given orientation.
  */

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/DualScreenTest.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/DualScreenTest.kt
@@ -5,8 +5,18 @@
 
 package com.microsoft.device.dualscreen.testing.filters
 
+import org.junit.Test
+
+/**
+ * Methods annotated with @[Test] that are also annotated with @DualScreenTest,
+ * will span the app to the entire display area
+ * and will rotate the device or emulator depending on the given orientation.
+ */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class DualScreenTest(
+    /**
+     * The requested device orientation.
+     */
     val orientation: Int = Int.MIN_VALUE
 )

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/DualScreenTest.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/DualScreenTest.kt
@@ -1,0 +1,12 @@
+/*
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License.
+ */
+
+package com.microsoft.device.dualscreen.testing.filters
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DualScreenTest(
+    val orientation: Int = Int.MIN_VALUE
+)

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/SingleScreenTest.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/SingleScreenTest.kt
@@ -5,6 +5,13 @@
 
 package com.microsoft.device.dualscreen.testing.filters
 
+import org.junit.Test
+
+/**
+ * Methods annotated with @[Test] that are also annotated with @SingleScreenTest,
+ * will keep the app visible only on the first display area
+ * and will rotate the device or emulator depending on the given orientation.
+ */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class SingleScreenTest(

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/SingleScreenTest.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/SingleScreenTest.kt
@@ -1,0 +1,12 @@
+/*
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License.
+ */
+
+package com.microsoft.device.dualscreen.testing.filters
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SingleScreenTest(
+    val orientation: Int = Int.MIN_VALUE
+)

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/SingleScreenTest.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/SingleScreenTest.kt
@@ -5,10 +5,8 @@
 
 package com.microsoft.device.dualscreen.testing.filters
 
-import org.junit.Test
-
 /**
- * Methods annotated with @[Test] that are also annotated with @SingleScreenTest,
+ * Test classes or test methods annotated with @SingleScreenTest,
  * will keep the app visible only on the first display area
  * and will rotate the device or emulator depending on the given orientation.
  */

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/TargetDevice.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/TargetDevice.kt
@@ -1,0 +1,12 @@
+/*
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License.
+ */
+
+package com.microsoft.device.dualscreen.testing.filters
+
+import com.microsoft.device.dualscreen.testing.DeviceModel
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class TargetDevice(val device: DeviceModel)

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/TargetDevice.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/TargetDevice.kt
@@ -7,11 +7,9 @@ package com.microsoft.device.dualscreen.testing.filters
 
 import com.microsoft.device.dualscreen.testing.DeviceModel
 import com.microsoft.device.dualscreen.testing.runner.FoldableJUnit4ClassRunner
-import org.junit.Test
 
 /**
- * Methods annotated with @[Test] that are also annotated with @TargetDevice,
- * will be run only on the specified device.
+ * Test classes or test methods annotated with @TargetDevice will run only on the specified device.
  * For example, if one test method is annotated with @TargetDevice(device = DeviceModel.SurfaceDuo),
  * then that test will run only on SurfaceDuo devices and emulators, otherwise will be skipped.
  *

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/TargetDevice.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/filters/TargetDevice.kt
@@ -6,7 +6,22 @@
 package com.microsoft.device.dualscreen.testing.filters
 
 import com.microsoft.device.dualscreen.testing.DeviceModel
+import com.microsoft.device.dualscreen.testing.runner.FoldableJUnit4ClassRunner
+import org.junit.Test
 
+/**
+ * Methods annotated with @[Test] that are also annotated with @TargetDevice,
+ * will be run only on the specified device.
+ * For example, if one test method is annotated with @TargetDevice(device = DeviceModel.SurfaceDuo),
+ * then that test will run only on SurfaceDuo devices and emulators, otherwise will be skipped.
+ *
+ * This annotation works only together with [FoldableJUnit4ClassRunner].
+ */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class TargetDevice(val device: DeviceModel)
+annotation class TargetDevice(
+    /**
+     * The requested device.
+     */
+    val device: DeviceModel
+)

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/DualScreenTestRule.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/DualScreenTestRule.kt
@@ -5,6 +5,7 @@
 
 package com.microsoft.device.dualscreen.testing.rules
 
+import android.annotation.SuppressLint
 import android.app.UiAutomation.ROTATION_FREEZE_0
 import android.app.UiAutomation.ROTATION_FREEZE_270
 import android.app.UiAutomation.ROTATION_FREEZE_90
@@ -36,6 +37,7 @@ import org.junit.runners.model.Statement
  * and methods annotated with [DualScreenTest] will span the app to entire display area.
  */
 @OptIn(ExperimentalWindowApi::class)
+@SuppressLint("RestrictedApi")
 class DualScreenTestRule : TestRule {
     private val uiDevice: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     private val flow = MutableSharedFlow<WindowLayoutInfo>(

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/DualScreenTestRule.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/DualScreenTestRule.kt
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License.
+ */
+
+package com.microsoft.device.dualscreen.testing.rules
+
+import android.app.UiAutomation.ROTATION_FREEZE_0
+import android.app.UiAutomation.ROTATION_FREEZE_270
+import android.app.UiAutomation.ROTATION_FREEZE_90
+import android.graphics.Rect
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import androidx.window.core.ExperimentalWindowApi
+import androidx.window.layout.FoldingFeature
+import androidx.window.layout.WindowInfoTracker
+import androidx.window.layout.WindowLayoutInfo
+import androidx.window.testing.layout.FoldingFeature
+import androidx.window.testing.layout.TestWindowLayoutInfo
+import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
+import com.microsoft.device.dualscreen.testing.filters.SingleScreenTest
+import com.microsoft.device.dualscreen.testing.isSurfaceDuo
+import com.microsoft.device.dualscreen.testing.resetOrientation
+import com.microsoft.device.dualscreen.testing.spanFromStart
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+@OptIn(ExperimentalWindowApi::class)
+class DualScreenTestRule : TestRule {
+    private val uiDevice: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    private val flow = MutableSharedFlow<WindowLayoutInfo>(
+        replay = 1,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    private val overrideServices = PublishWindowInfoTrackerDecorator(flow)
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                before(description)
+                try {
+                    base.evaluate()
+                } finally {
+                    after()
+                }
+            }
+        }
+    }
+
+    private fun before(description: Description?) {
+        val dualScreenTest = description?.getAnnotation(DualScreenTest::class.java)
+        val singleScreenTest = description?.getAnnotation(SingleScreenTest::class.java)
+        val requestedDeviceOrientation = dualScreenTest?.orientation ?: singleScreenTest?.orientation ?: ROTATION_FREEZE_0
+
+        val runDualScreenTest = dualScreenTest != null
+        if (uiDevice.isSurfaceDuo()) {
+            if (runDualScreenTest) {
+                uiDevice.spanFromStart()
+            }
+        } else {
+            WindowInfoTracker.overrideDecorator(overrideServices)
+            mockFoldingFeature(requestedDeviceOrientation, runDualScreenTest)
+        }
+
+        rotateDevice(requestedDeviceOrientation)
+    }
+
+    private fun rotateDevice(requestedDeviceOrientation: Int) {
+        when (requestedDeviceOrientation) {
+            ROTATION_FREEZE_270 -> uiDevice.setOrientationRight()
+            ROTATION_FREEZE_90 -> uiDevice.setOrientationLeft()
+            ROTATION_FREEZE_0 -> uiDevice.setOrientationNatural()
+        }
+    }
+
+    private fun mockFoldingFeature(deviceOrientation: Int, forDualScreenTest: Boolean) {
+        val displayFeatures = if (forDualScreenTest) {
+            val foldingFeature = FoldingFeature(
+                windowBounds = Rect(0, 0, uiDevice.displayWidth, uiDevice.displayHeight),
+                state = FoldingFeature.State.FLAT,
+                size = 0,
+                orientation = getFoldingFeatureOrientation(deviceOrientation)
+            )
+            listOf(foldingFeature)
+        } else {
+            emptyList()
+        }
+        val windowLayoutInfo = TestWindowLayoutInfo(displayFeatures)
+        overrideWindowLayoutInfo(windowLayoutInfo)
+    }
+
+    private fun getFoldingFeatureOrientation(deviceOrientation: Int): FoldingFeature.Orientation {
+        return when (deviceOrientation) {
+            ROTATION_FREEZE_270,
+            ROTATION_FREEZE_90 -> FoldingFeature.Orientation.HORIZONTAL
+            else -> FoldingFeature.Orientation.VERTICAL
+        }
+    }
+
+    private fun after() {
+        uiDevice.resetOrientation()
+        WindowInfoTracker.reset()
+    }
+
+    private fun overrideWindowLayoutInfo(info: WindowLayoutInfo) {
+        flow.tryEmit(info)
+    }
+}

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/DualScreenTestRule.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/DualScreenTestRule.kt
@@ -28,6 +28,12 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
+/**
+ * Custom [TestRule] that can be used together with [SingleScreenTest] and [DualScreenTest]
+ * in order to run tests on the specified posture.
+ * Test methods annotated with [SingleScreenTest] will keep or unspan the app to first display area,
+ * and methods annotated with [DualScreenTest] will span the app to entire display area.
+ */
 @OptIn(ExperimentalWindowApi::class)
 class DualScreenTestRule : TestRule {
     private val uiDevice: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/DualScreenTestRule.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/DualScreenTestRule.kt
@@ -112,7 +112,7 @@ class DualScreenTestRule : TestRule {
         val displayFeatures = if (forDualScreenTest) {
             val foldingFeature = FoldingFeature(
                 windowBounds = Rect(0, 0, uiDevice.displayWidth, uiDevice.displayHeight),
-                state = FoldingFeature.State.FLAT,
+                state = FoldingFeature.State.HALF_OPENED,
                 size = 0,
                 orientation = getFoldingFeatureOrientation(deviceOrientation)
             )

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/PublishLayoutInfoTracker.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/PublishLayoutInfoTracker.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.device.dualscreen.testing.rules
+
+import android.app.Activity
+import androidx.window.layout.WindowInfoTracker
+import androidx.window.layout.WindowLayoutInfo
+import kotlinx.coroutines.flow.Flow
+
+internal class PublishLayoutInfoTracker(
+    private val core: WindowInfoTracker,
+    private val flow: Flow<WindowLayoutInfo>
+) : WindowInfoTracker by core {
+
+    override fun windowLayoutInfo(activity: Activity): Flow<WindowLayoutInfo> {
+        return flow
+    }
+}

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/PublishWindowInfoTrackerDecorator.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/PublishWindowInfoTrackerDecorator.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.device.dualscreen.testing.rules
+
+import androidx.window.layout.WindowInfoTracker
+import androidx.window.layout.WindowInfoTrackerDecorator
+import androidx.window.layout.WindowLayoutInfo
+import kotlinx.coroutines.flow.Flow
+
+internal class PublishWindowInfoTrackerDecorator(
+    private val flow: Flow<WindowLayoutInfo>
+) : WindowInfoTrackerDecorator {
+    override fun decorate(tracker: WindowInfoTracker): WindowInfoTracker {
+        return PublishLayoutInfoTracker(tracker, flow)
+    }
+}

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/PublishWindowInfoTrackerDecorator.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/PublishWindowInfoTrackerDecorator.kt
@@ -16,11 +16,13 @@
 
 package com.microsoft.device.dualscreen.testing.rules
 
+import android.annotation.SuppressLint
 import androidx.window.layout.WindowInfoTracker
 import androidx.window.layout.WindowInfoTrackerDecorator
 import androidx.window.layout.WindowLayoutInfo
 import kotlinx.coroutines.flow.Flow
 
+@SuppressLint("RestrictedApi")
 internal class PublishWindowInfoTrackerDecorator(
     private val flow: Flow<WindowLayoutInfo>
 ) : WindowInfoTrackerDecorator {

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/TestRules.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/TestRules.kt
@@ -5,15 +5,17 @@
 
 package com.microsoft.device.dualscreen.testing.rules
 
+import android.app.Activity
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.microsoft.device.dualscreen.testing.isSurfaceDuo
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
 
-fun foldableTestRule(
-    activityScenarioRule: TestRule,
-    dualScreenTestRule: TestRule,
+fun <A : Activity> foldableTestRule(
+    activityScenarioRule: ActivityScenarioRule<A>,
+    dualScreenTestRule: DualScreenTestRule,
     vararg aroundRules: TestRule
 ): TestRule {
     val uiDevice: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/TestRules.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/rules/TestRules.kt
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License.
+ */
+
+package com.microsoft.device.dualscreen.testing.rules
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import com.microsoft.device.dualscreen.testing.isSurfaceDuo
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+
+fun foldableTestRule(
+    activityScenarioRule: TestRule,
+    dualScreenTestRule: TestRule,
+    vararg aroundRules: TestRule
+): TestRule {
+    val uiDevice: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+    var ruleChain = if (uiDevice.isSurfaceDuo()) {
+        RuleChain.outerRule(activityScenarioRule).around(dualScreenTestRule)
+    } else {
+        RuleChain.outerRule(dualScreenTestRule).around(activityScenarioRule)
+    }
+
+    aroundRules.forEach {
+        ruleChain = ruleChain.around(it)
+    }
+    return ruleChain
+}

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/runner/FoldableJUnit4ClassRunner.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/runner/FoldableJUnit4ClassRunner.kt
@@ -10,12 +10,17 @@ import androidx.test.internal.util.AndroidRunnerParams
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.microsoft.device.dualscreen.testing.DeviceModel
+import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
+import com.microsoft.device.dualscreen.testing.filters.SingleScreenTest
 import com.microsoft.device.dualscreen.testing.filters.TargetDevice
 import com.microsoft.device.dualscreen.testing.isSurfaceDuo
+import org.junit.runner.Description
+import org.junit.runner.notification.RunNotifier
 import org.junit.runners.model.FrameworkMethod
 
 /**
- * A specialized [AndroidJUnit4ClassRunner] that can be used together with the [TargetDevice] annotation
+ * A specialized [AndroidJUnit4ClassRunner] that can be used together with the
+ * [SingleScreenTest], [DualScreenTest] and [TargetDevice] annotations
  * to filter the tests that will run on the specified devices.
  * For example, if a test method is annotated with @TargetDevice(device = DeviceModel.SurfaceDuo),
  * that test method will run only on SurfaceDuo device or emulator, otherwise will be skipped.
@@ -25,15 +30,34 @@ class FoldableJUnit4ClassRunner : AndroidJUnit4ClassRunner {
 
     constructor(klass: Class<*>?, runnerParams: AndroidRunnerParams) : super(klass, runnerParams)
 
-    override fun computeTestMethods(): MutableList<FrameworkMethod> {
+//    override fun computeTestMethods(): MutableList<FrameworkMethod> {
+//        val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+//        val testMethods: MutableList<FrameworkMethod> = super.computeTestMethods()
+//        return testMethods.filter { method ->
+//            val targetDevice: TargetDevice? = method.getAnnotation(TargetDevice::class.java)
+//            (targetDevice == null) ||
+//                (!targetDevice.device.isSurfaceDuo && !uiDevice.isSurfaceDuo()) ||
+//                (targetDevice.device.isSurfaceDuo && uiDevice.isSurfaceDuo())
+//        }.toMutableList()
+//    }
+
+    override fun runChild(method: FrameworkMethod?, notifier: RunNotifier?) {
+        val description = describeChild(method)
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        val testMethods: MutableList<FrameworkMethod> = super.computeTestMethods()
-        return testMethods.filter { method ->
-            val targetDevice: TargetDevice? = method.getAnnotation(TargetDevice::class.java)
-            (targetDevice == null) ||
-                (!targetDevice.device.isSurfaceDuo && !uiDevice.isSurfaceDuo()) ||
-                (targetDevice.device.isSurfaceDuo && uiDevice.isSurfaceDuo())
-        }.toMutableList()
+        val targetDevice: TargetDevice? = getAnnotation(description, TargetDevice::class.java)
+        if ((targetDevice == null) ||
+            (!targetDevice.device.isSurfaceDuo && !uiDevice.isSurfaceDuo()) ||
+            (targetDevice.device.isSurfaceDuo && uiDevice.isSurfaceDuo())
+        ) {
+            runLeaf(methodBlock(method), description, notifier)
+        } else {
+            notifier?.fireTestIgnored(description)
+        }
+    }
+
+    private fun <T : Annotation> getAnnotation(description: Description, annotationClass: Class<T>): T? {
+        return description.testClass.getAnnotation(annotationClass)
+            ?: description.getAnnotation(annotationClass)
     }
 
     private val DeviceModel?.isSurfaceDuo: Boolean

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/runner/FoldableJUnit4ClassRunner.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/runner/FoldableJUnit4ClassRunner.kt
@@ -30,17 +30,6 @@ class FoldableJUnit4ClassRunner : AndroidJUnit4ClassRunner {
 
     constructor(klass: Class<*>?, runnerParams: AndroidRunnerParams) : super(klass, runnerParams)
 
-//    override fun computeTestMethods(): MutableList<FrameworkMethod> {
-//        val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-//        val testMethods: MutableList<FrameworkMethod> = super.computeTestMethods()
-//        return testMethods.filter { method ->
-//            val targetDevice: TargetDevice? = method.getAnnotation(TargetDevice::class.java)
-//            (targetDevice == null) ||
-//                (!targetDevice.device.isSurfaceDuo && !uiDevice.isSurfaceDuo()) ||
-//                (targetDevice.device.isSurfaceDuo && uiDevice.isSurfaceDuo())
-//        }.toMutableList()
-//    }
-
     override fun runChild(method: FrameworkMethod?, notifier: RunNotifier?) {
         val description = describeChild(method)
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/runner/FoldableJUnit4ClassRunner.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/runner/FoldableJUnit4ClassRunner.kt
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License.
+ */
+
+package com.microsoft.device.dualscreen.testing.runner
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import androidx.test.internal.util.AndroidRunnerParams
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import com.microsoft.device.dualscreen.testing.DeviceModel
+import com.microsoft.device.dualscreen.testing.filters.TargetDevice
+import com.microsoft.device.dualscreen.testing.isSurfaceDuo
+import org.junit.runners.model.FrameworkMethod
+
+class FoldableJUnit4ClassRunner : AndroidJUnit4ClassRunner {
+    constructor(klass: Class<*>?) : super(klass)
+
+    constructor(klass: Class<*>?, runnerParams: AndroidRunnerParams) : super(klass, runnerParams)
+
+    override fun computeTestMethods(): MutableList<FrameworkMethod> {
+        val testMethods: MutableList<FrameworkMethod> = super.computeTestMethods()
+        if (testMethods.size == 0) return testMethods
+
+        val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        return testMethods.filter { method ->
+            val targetDevice: TargetDevice? = method.getAnnotation(TargetDevice::class.java)
+            (targetDevice == null) ||
+                (!targetDevice.device.isSurfaceDuo && !uiDevice.isSurfaceDuo()) ||
+                (targetDevice.device.isSurfaceDuo && uiDevice.isSurfaceDuo())
+        }.toMutableList()
+    }
+
+    private val DeviceModel?.isSurfaceDuo: Boolean
+        get() = this == DeviceModel.SurfaceDuo || this == DeviceModel.SurfaceDuo2
+}

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/runner/FoldableJUnit4ClassRunner.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/runner/FoldableJUnit4ClassRunner.kt
@@ -14,6 +14,7 @@ import com.microsoft.device.dualscreen.testing.filters.DualScreenTest
 import com.microsoft.device.dualscreen.testing.filters.SingleScreenTest
 import com.microsoft.device.dualscreen.testing.filters.TargetDevice
 import com.microsoft.device.dualscreen.testing.isSurfaceDuo
+import org.junit.Test
 import org.junit.runner.Description
 import org.junit.runner.notification.RunNotifier
 import org.junit.runners.model.FrameworkMethod
@@ -41,6 +42,27 @@ class FoldableJUnit4ClassRunner : AndroidJUnit4ClassRunner {
             runLeaf(methodBlock(method), description, notifier)
         } else {
             notifier?.fireTestIgnored(description)
+        }
+    }
+
+    override fun validateTestMethods(errors: MutableList<Throwable>?) {
+        super.validateTestMethods(errors)
+        val methods = testClass.getAnnotatedMethods(Test::class.java)
+        methods.forEach { method ->
+            method.validateFoldableTestAnnotations(errors)
+        }
+    }
+
+    private fun FrameworkMethod.validateFoldableTestAnnotations(errors: MutableList<Throwable>?) {
+        val singleScreenTestAnnotation = method.getAnnotation(SingleScreenTest::class.java)
+        val dualScreenTestAnnotation = method.getAnnotation(DualScreenTest::class.java)
+        if (singleScreenTestAnnotation != null && dualScreenTestAnnotation != null) {
+            errors?.add(
+                Exception(
+                    "Method " + method.name + " should be annotated with only " +
+                        "@${SingleScreenTest::class.java.simpleName} or @${DualScreenTest::class.java.simpleName}"
+                )
+            )
         }
     }
 

--- a/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/runner/FoldableJUnit4ClassRunner.kt
+++ b/utils/test-utils/src/main/java/com/microsoft/device/dualscreen/testing/runner/FoldableJUnit4ClassRunner.kt
@@ -14,16 +14,20 @@ import com.microsoft.device.dualscreen.testing.filters.TargetDevice
 import com.microsoft.device.dualscreen.testing.isSurfaceDuo
 import org.junit.runners.model.FrameworkMethod
 
+/**
+ * A specialized [AndroidJUnit4ClassRunner] that can be used together with the [TargetDevice] annotation
+ * to filter the tests that will run on the specified devices.
+ * For example, if a test method is annotated with @TargetDevice(device = DeviceModel.SurfaceDuo),
+ * that test method will run only on SurfaceDuo device or emulator, otherwise will be skipped.
+ */
 class FoldableJUnit4ClassRunner : AndroidJUnit4ClassRunner {
     constructor(klass: Class<*>?) : super(klass)
 
     constructor(klass: Class<*>?, runnerParams: AndroidRunnerParams) : super(klass, runnerParams)
 
     override fun computeTestMethods(): MutableList<FrameworkMethod> {
-        val testMethods: MutableList<FrameworkMethod> = super.computeTestMethods()
-        if (testMethods.size == 0) return testMethods
-
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        val testMethods: MutableList<FrameworkMethod> = super.computeTestMethods()
         return testMethods.filter { method ->
             val targetDevice: TargetDevice? = method.getAnnotation(TargetDevice::class.java)
             (targetDevice == null) ||


### PR DESCRIPTION
<!---
Instructions: Please, fill the following sections with the information that is suggested in the comments. You can leave the comments or delete them, it won't be shown in the PR.
-->

## 📃 Description
Added @SingleScreenTest, @DualScreenTest, @TargetDevice, @DeviceOrientation annotations in order to easily write tests for Foldable devices

## 🤔 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?
I used this annotations inside the SDK components tests

## ⚒️ Does the PR contain new tests or refactored old ones?
Containes refactored tests with the new annotations

## 📷 Screenshots (if appropriate)
Not needed

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement to a current functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue. Please add issue link here too).

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] This PR contains new tests that cover the new code.
- [x] This PR refactor previous tests to cover the new code.
- [ ] This PR is part of a set of PRs that build a bigger feature. If so, please, add here links to previously merged or open PRs.

<!--
Credits:
- [Cortinico](https://github.com/cortinico/kotlin-android-template/tree/main/.github)
- [Fluent UI team](https://github.com/microsoft/fluentui-android/tree/master/.github)

for their fantastic templates that have helped us as inspiration.
-->